### PR TITLE
Support Android AMediaCodec (#2552)

### DIFF
--- a/aconfigure
+++ b/aconfigure
@@ -650,6 +650,7 @@ openssl_h_present
 ac_ssl_backend
 ac_ssl_has_aes_gcm
 ac_no_ssl
+ac_no_mediacodec
 ac_vpx_ldflags
 ac_vpx_cflags
 ac_openh264_ldflags
@@ -822,6 +823,7 @@ enable_ipp
 with_ipp
 with_ipp_samples
 with_ipp_arch
+enable_android_mediacodec
 with_ssl
 with_gnutls
 enable_darwin_ssl
@@ -1494,6 +1496,8 @@ Optional Features:
                           package and samples location using IPPROOT and
                           IPPSAMPLES env var or with --with-ipp and
                           --with-ipp-samples options
+  --disable-android-mediacodec
+                          Exclude Android MediaCodec (default: autodetect)
   --disable-darwin-ssl    Exclude Darwin SSL (default: autodetect)
   --disable-ssl           Exclude SSL support the build (default: autodetect)
 
@@ -8002,6 +8006,73 @@ export IPP_LIBS=$IPP_LIBS"
 else
     { $as_echo "$as_me:${as_lineno-$LINENO}: result: Skipping Intel IPP settings (not wanted)" >&5
 $as_echo "Skipping Intel IPP settings (not wanted)" >&6; }
+fi
+
+
+
+# Check whether --enable-android-mediacodec was given.
+if test "${enable_android_mediacodec+set}" = set; then :
+  enableval=$enable_android_mediacodec; if test "$enable_android_mediacodec" = "no"; then
+	     ac_no_mediacodec=1
+		 { $as_echo "$as_me:${as_lineno-$LINENO}: result: Checking if Android MediaCodec support is disabled... yes" >&5
+$as_echo "Checking if Android MediaCodec support is disabled... yes" >&6; }
+	        fi
+else
+
+		case $target in
+        *android*)
+	      { $as_echo "$as_me:${as_lineno-$LINENO}: checking for AMediaCodec_createDecoderByType in -lmediandk" >&5
+$as_echo_n "checking for AMediaCodec_createDecoderByType in -lmediandk... " >&6; }
+if ${ac_cv_lib_mediandk_AMediaCodec_createDecoderByType+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  ac_check_lib_save_LIBS=$LIBS
+LIBS="-lmediandk  $LIBS"
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+/* Override any GCC internal prototype to avoid an error.
+   Use char because int might match the return type of a GCC
+   builtin and then its argument prototype would still apply.  */
+#ifdef __cplusplus
+extern "C"
+#endif
+char AMediaCodec_createDecoderByType ();
+int
+main ()
+{
+return AMediaCodec_createDecoderByType ();
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_link "$LINENO"; then :
+  ac_cv_lib_mediandk_AMediaCodec_createDecoderByType=yes
+else
+  ac_cv_lib_mediandk_AMediaCodec_createDecoderByType=no
+fi
+rm -f core conftest.err conftest.$ac_objext \
+    conftest$ac_exeext conftest.$ac_ext
+LIBS=$ac_check_lib_save_LIBS
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_mediandk_AMediaCodec_createDecoderByType" >&5
+$as_echo "$ac_cv_lib_mediandk_AMediaCodec_createDecoderByType" >&6; }
+if test "x$ac_cv_lib_mediandk_AMediaCodec_createDecoderByType" = xyes; then :
+  ac_pjmedia_has_amediacodec=1 && LIBS="-lmediandk $LIBS"
+fi
+
+	      if test "x$ac_pjmedia_has_amediacodec" = "x1"; then
+		    { $as_echo "$as_me:${as_lineno-$LINENO}: result: Checking if Android AMediaCodec library is available... yes" >&5
+$as_echo "Checking if Android AMediaCodec library is available... yes" >&6; }
+		    $as_echo "#define PJMEDIA_HAS_ANDROID_MEDIACODEC 1" >>confdefs.h
+
+	      else
+		    { $as_echo "$as_me:${as_lineno-$LINENO}: result: Checking if Android AMediaCodec library is available... no" >&5
+$as_echo "Checking if Android AMediaCodec library is available... no" >&6; }
+	      fi
+		  ;;
+		esac
+
 fi
 
 

--- a/aconfigure.ac
+++ b/aconfigure.ac
@@ -1598,6 +1598,29 @@ else
     AC_MSG_RESULT([Skipping Intel IPP settings (not wanted)])
 fi
 
+dnl # Include Android MediaCodec
+AC_SUBST(ac_no_mediacodec)
+
+AC_ARG_ENABLE(android-mediacodec,
+	      AS_HELP_STRING([--disable-android-mediacodec],
+			     [Exclude Android MediaCodec (default: autodetect)]),
+	      [if test "$enable_android_mediacodec" = "no"; then
+	     [ac_no_mediacodec=1]
+		 AC_MSG_RESULT([Checking if Android MediaCodec support is disabled... yes])
+	        fi],
+	      [
+		case $target in
+        *android*)
+	      AC_CHECK_LIB(mediandk,AMediaCodec_createDecoderByType,[ac_pjmedia_has_amediacodec=1 && LIBS="-lmediandk $LIBS"])
+	      if test "x$ac_pjmedia_has_amediacodec" = "x1"; then
+		    AC_MSG_RESULT([Checking if Android AMediaCodec library is available... yes])
+		    AC_DEFINE(PJMEDIA_HAS_ANDROID_MEDIACODEC, 1)
+	      else
+		    AC_MSG_RESULT([Checking if Android AMediaCodec library is available... no])
+	      fi
+		  ;;
+		esac
+	      ])
 
 dnl ##########################################
 dnl #

--- a/pjmedia/build/Makefile
+++ b/pjmedia/build/Makefile
@@ -136,7 +136,7 @@ export PJSDP_LDFLAGS += $(PJMEDIA_LDLIB) \
 #
 export PJMEDIA_CODEC_SRCDIR = ../src/pjmedia-codec
 export PJMEDIA_CODEC_OBJS += audio_codecs.o ffmpeg_vid_codecs.o openh264.o \
-			h263_packetizer.o h264_packetizer.o \
+			h263_packetizer.o h264_packetizer.o vpx_packetizer.o \
 			$(OS_OBJS) $(M_OBJS) $(CC_OBJS) $(HOST_OBJS) \
 			ipp_codecs.o silk.o opus.o $(CODEC_OBJS) \
                         g7221_sdp_match.o amr_sdp_match.o passthrough.o \

--- a/pjmedia/build/os-auto.mak.in
+++ b/pjmedia/build/os-auto.mak.in
@@ -67,6 +67,7 @@ AC_NO_G7221_CODEC=@ac_no_g7221_codec@
 AC_NO_OPENCORE_AMRNB=@ac_no_opencore_amrnb@
 AC_NO_OPENCORE_AMRWB=@ac_no_opencore_amrwb@
 AC_NO_BCG729=@ac_no_bcg729@
+AC_NO_ANDROID_MEDIACODEC=@ac_no_mediacodec@
 
 export CODEC_OBJS=
 
@@ -139,6 +140,11 @@ ifeq ($(AC_NO_BCG729),)
 export CODEC_OBJS += bcg729.o
 endif
 
+ifeq ($(AC_NO_ANDROID_MEDIACODEC),1)
+export CFLAGS += -DPJMEDIA_HAS_ANDROID_MEDIACODEC=0
+else
+export CODEC_OBJS += and_aud_mediacodec.o and_vid_mediacodec.o
+endif
 
 #
 # SRTP

--- a/pjmedia/build/pjmedia_codec.vcproj
+++ b/pjmedia/build/pjmedia_codec.vcproj
@@ -3631,8 +3631,12 @@
       <File
 				RelativePath="..\src\pjmedia-codec\vpx.c"
 				>
-      </File>        
-			<Filter
+      </File>
+      <File
+				RelativePath="..\src\pjmedia-codec\vpx_packetizer.c"
+				>
+      </File>
+      <Filter
 				Name="g722 Files"
 				>
 				<File
@@ -3744,8 +3748,12 @@
       <File
 				RelativePath="..\include\pjmedia-codec\vpx.h"
 				>
-      </File>      
-		</Filter>
+      </File>
+      <File
+				RelativePath="..\include\pjmedia-codec\vpx_packetizer.h"
+				>
+      </File>
+    </Filter>
 	</Files>
 	<Globals>
 	</Globals>

--- a/pjmedia/build/pjmedia_codec.vcxproj
+++ b/pjmedia/build/pjmedia_codec.vcxproj
@@ -531,6 +531,7 @@
     <ClCompile Include="..\src\pjmedia-codec\silk.c" />
     <ClCompile Include="..\src\pjmedia-codec\speex_codec.c" />
     <ClCompile Include="..\src\pjmedia-codec\vpx.c" />
+    <ClCompile Include="..\src\pjmedia-codec\vpx_packetizer.c" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\include\pjmedia-codec.h" />
@@ -556,6 +557,7 @@
     <ClInclude Include="..\include\pjmedia-codec\speex.h" />
     <ClInclude Include="..\include\pjmedia-codec\types.h" />
     <ClInclude Include="..\include\pjmedia-codec\vpx.h" />
+    <ClInclude Include="..\include\pjmedia-codec\vpx_packetizer.h" />
     <ClInclude Include="..\src\pjmedia-codec\g722\g722_dec.h" />
     <ClInclude Include="..\src\pjmedia-codec\g722\g722_enc.h" />
   </ItemGroup>

--- a/pjmedia/build/pjmedia_codec.vcxproj.filters
+++ b/pjmedia/build/pjmedia_codec.vcxproj.filters
@@ -80,6 +80,9 @@
     <ClCompile Include="..\src\pjmedia-codec\vpx.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\src\pjmedia-codec\vpx_packetizer.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\src\pjmedia-codec\g722\g722_dec.h">
@@ -155,6 +158,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\include\pjmedia-codec\vpx.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\include\pjmedia-codec\vpx_packetizer.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/pjmedia/include/pjmedia-codec.h
+++ b/pjmedia/include/pjmedia-codec.h
@@ -24,7 +24,8 @@
  * @file pjmedia-codec.h
  * @brief Include all codecs API in PJMEDIA-CODEC
  */
-
+#include <pjmedia-codec/and_aud_mediacodec.h>
+#include <pjmedia-codec/and_vid_mediacodec.h>
 #include <pjmedia-codec/audio_codecs.h>
 #include <pjmedia-codec/bcg729.h>
 #include <pjmedia-codec/ffmpeg_vid_codecs.h>

--- a/pjmedia/include/pjmedia-codec/and_aud_mediacodec.h
+++ b/pjmedia/include/pjmedia-codec/and_aud_mediacodec.h
@@ -1,0 +1,131 @@
+/*
+ * Copyright (C)2020 Teluu Inc. (http://www.teluu.com)
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
+#ifndef __PJMEDIA_CODEC_AND_AUD_MEDIACODEC_H__
+#define __PJMEDIA_CODEC_AND_AUD_MEDIACODEC_H__
+
+/**
+ * @file and_aud_mediacodec.h
+ * @brief Android audio MediaCodec codecs.
+ */
+
+#include <pjmedia-codec/types.h>
+
+/**
+ * @defgroup PJMEDIA_CODEC_AUD_MEDIACODEC Audio MediaCodec Codec
+ * @ingroup PJMEDIA_CODEC_CODECS
+ * @{
+ *
+ * Audio MediaCodec codec wrapper for Android.
+ *
+ * This codec wrapper contains varius codecs: i.e: AMR and AMR-WB.
+ *
+ * \section pjmedia_codec_mediacodec_AMR MediaCodec AMRNB/AMR-WB
+ *
+ * MediaCodec AMR supports 16-bit PCM audio signal with sampling rate 8000Hz,
+ * 20ms frame length and producing various bitrates that ranges from 4.75kbps
+ * to 12.2kbps.
+ * \subsection codec_setting Codec Settings
+ *
+ * General codec settings for this codec such as VAD and PLC can be
+ * manipulated through the <tt>setting</tt> field in #pjmedia_codec_param.
+ * Please see the documentation of #pjmedia_codec_param for more info.
+ * Note that MediaCodec doesn't provide internal VAD/PLC feature, they will be
+ * provided by PJMEDIA instead.
+ *
+ * \subsubsection bitrate Bitrate
+ *
+ * By default, encoding bitrate is 7400bps. This default setting can be
+ * modified using #pjmedia_codec_mgr_set_default_param() by specifying
+ * prefered AMR bitrate in field <tt>info::avg_bps</tt> of
+ * #pjmedia_codec_param. Valid bitrates could be seen in
+ * #pjmedia_codec_amrnb_bitrates.
+ *
+ * \subsubsection payload_format Payload Format
+ *
+ * There are two AMR payload format types, bandwidth-efficient and
+ * octet-aligned. Default setting is using octet-aligned. This default payload
+ * format can be modified using #pjmedia_codec_mgr_set_default_param().
+ *
+ * In #pjmedia_codec_param, payload format can be set by specifying SDP
+ * format parameters "octet-align" in the SDP "a=fmtp" attribute for
+ * decoding direction. Valid values are "0" (for bandwidth efficient mode)
+ * and "1" (for octet-aligned mode).
+ *
+ * \subsubsection mode_set Mode-Set
+ *
+ * Mode-set is used for restricting AMR modes in decoding direction.
+ *
+ * By default, no mode-set restriction applied. This default setting can be
+ * be modified using #pjmedia_codec_mgr_set_default_param().
+ *
+ * In #pjmedia_codec_param, mode-set could be specified via format parameters
+ * "mode-set" in the SDP "a=fmtp" attribute for decoding direction. Valid
+ * value is a comma separated list of modes from the set 0 - 7, e.g:
+ * "4,5,6,7". When this parameter is omitted, no mode-set restrictions applied.
+ *
+ * Here is an example of modifying AMR default codec param:
+ \code
+    pjmedia_codec_param param;
+
+    pjmedia_codec_mgr_get_default_param(.., &param);
+    ...
+    // set default encoding bitrate to the highest 12.2kbps
+    param.info.avg_bps = 12200;
+
+    // restrict decoding bitrate to 10.2kbps and 12.2kbps only
+    param.setting.dec_fmtp.param[0].name = pj_str("mode-set");
+    param.setting.dec_fmtp.param[0].val  = pj_str("6,7");
+
+    // also set to use bandwidth-efficient payload format
+    param.setting.dec_fmtp.param[1].name = pj_str("octet-align");
+    param.setting.dec_fmtp.param[1].val  = pj_str("0");
+
+    param.setting.dec_fmtp.cnt = 2;
+    ...
+    pjmedia_codec_mgr_set_default_param(.., &param);
+ \endcode
+ */
+
+PJ_BEGIN_DECL
+
+/**
+ * Initialize and register Android audio MediaCodec factory to pjmedia
+ * endpoint.
+ *
+ * @param endpt		The pjmedia endpoint.
+ *
+ * @return		PJ_SUCCESS on success.
+ */
+PJ_DECL(pj_status_t) pjmedia_codec_and_media_aud_init( pjmedia_endpt *endpt );
+
+/**
+ * Unregister Android audio MediaCodec factory from pjmedia endpoint 
+ * and deinitialize the codec library.
+ *
+ * @return	    PJ_SUCCESS on success.
+ */
+PJ_DECL(pj_status_t) pjmedia_codec_and_media_aud_deinit( void );
+
+PJ_END_DECL
+
+/**
+ * @}
+ */
+
+#endif	/* __PJMEDIA_CODEC_AND_AUD_MEDIACODEC_H__ */

--- a/pjmedia/include/pjmedia-codec/and_vid_mediacodec.h
+++ b/pjmedia/include/pjmedia-codec/and_vid_mediacodec.h
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C)2020 Teluu Inc. (http://www.teluu.com)
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
+#ifndef __PJMEDIA_CODEC_AND_VID_MEDIACODEC_H__
+#define __PJMEDIA_CODEC_AND_VID_MEDIACODEC_H__
+
+#include <pjmedia-codec/types.h>
+#include <pjmedia/vid_codec.h>
+
+/**
+ * @file pjmedia-codec/and_vid_mediacodec.h
+ * @brief Android video Mediacodec codecs.
+ */
+
+PJ_BEGIN_DECL
+
+/**
+ * @defgroup PJMEDIA_HAS_ANDROID_MEDIACODEC Android Mediacodec Codec
+ * @ingroup PJMEDIA_CODEC_VID_CODECS
+ * @{
+ *
+ *
+ * Video MediaCodec codec wrapper for Android.
+ *
+ * This codec wrapper contains varius codecs: i.e: H.264/AVC, VP8 and VP9.
+ * The H.264 codec wrapper only supports non-interleaved packetization
+ * mode. If remote uses a different mode (e.g: single-nal), this will cause
+ * unpacketization issue and affect decoding process.
+ */
+
+/**
+ * Initialize and register Android Mediacodec video codec factory.
+ *
+ * @param mgr	    The video codec manager instance where this codec will
+ * 		    be registered to. Specify NULL to use default instance
+ * 		    (in that case, an instance of video codec manager must
+ * 		    have been created beforehand).
+ * @param pf	    Pool factory.
+ *
+ * @return	    PJ_SUCCESS on success.
+ */
+PJ_DECL(pj_status_t) pjmedia_codec_and_media_vid_init(
+				    pjmedia_vid_codec_mgr *mgr,
+                                    pj_pool_factory *pf);
+
+/**
+ * Unregister Android Mediacodec video codecs factory from the video codec
+ * manager and deinitialize the codec library.
+ *
+ * @return	    PJ_SUCCESS on success.
+ */
+PJ_DECL(pj_status_t) pjmedia_codec_and_media_vid_deinit(void);
+
+
+/**
+ * @}
+ */
+
+
+PJ_END_DECL
+
+#endif	/* __PJMEDIA_CODEC_AND_VID_MEDIACODEC_H__ */

--- a/pjmedia/include/pjmedia-codec/config.h
+++ b/pjmedia/include/pjmedia-codec/config.h
@@ -600,6 +600,75 @@
 #endif
 
 /**
+ * Enable Android MediaCodec AMRNB codec.
+ *
+ * Default: 1
+ */
+#ifndef PJMEDIA_HAS_AND_MEDIA_AMRNB
+#   define PJMEDIA_HAS_AND_MEDIA_AMRNB		1
+#endif
+
+/**
+ * Enable Android MediaCodec AMRWB codec.
+ *
+ * Default: 1
+ */
+#ifndef PJMEDIA_HAS_AND_MEDIA_AMRWB
+#   define PJMEDIA_HAS_AND_MEDIA_AMRWB		1
+#endif
+
+/**
+ * Enable Android MediaCodec AVC/H264 codec.
+ *
+ * Default: 1
+ */
+#ifndef PJMEDIA_HAS_AND_MEDIA_H264
+#   define PJMEDIA_HAS_AND_MEDIA_H264		1
+#endif
+
+/**
+ * Enable Android MediaCodec VP8 codec.
+ *
+ * Default: 1
+ */
+#ifndef PJMEDIA_HAS_AND_MEDIA_VP8
+#   define PJMEDIA_HAS_AND_MEDIA_VP8		1
+#endif
+
+/**
+ * Enable Android MediaCodec VP9 codec.
+ *
+ * Default: 1
+ */
+#ifndef PJMEDIA_HAS_AND_MEDIA_VP9
+#   define PJMEDIA_HAS_AND_MEDIA_VP9		1
+#endif
+
+/**
+ * Prioritize to use software video encoder on Android MediaCodec.
+ * Set to 0 to prioritize Hardware encoder.
+ * Note: based on test, software encoder configuration provided the most stable
+ * configuration.
+ *
+ * Default: 1
+ */
+#ifndef PJMEDIA_AND_MEDIA_PRIO_SW_VID_ENC
+#    define PJMEDIA_AND_MEDIA_PRIO_SW_VID_ENC 	1
+#endif
+
+/**
+ * Prioritize to use software video encoder on Android MediaCodec.
+ * Set to 0 to prioritize Hardware encoder.
+ * Note: based on test, software decoder configuration provided the most stable
+ * configuration.
+ *
+ * Default: 1
+ */
+#ifndef PJMEDIA_AND_MEDIA_PRIO_SW_VID_DEC
+#    define PJMEDIA_AND_MEDIA_PRIO_SW_VID_DEC 	1
+#endif
+
+/**
  * @}
  */
 

--- a/pjmedia/include/pjmedia-codec/config_auto.h.in
+++ b/pjmedia/include/pjmedia-codec/config_auto.h.in
@@ -94,6 +94,11 @@
 #undef PJMEDIA_HAS_BCG729
 #endif
 
+/* Android MediCodec codecs */
+#ifndef PJMEDIA_HAS_ANDROID_MEDIACODEC
+#undef PJMEDIA_HAS_ANDROID_MEDIACODEC
+#endif
+
 #endif	/* __PJMEDIA_CODEC_CONFIG_AUTO_H_ */
 
 

--- a/pjmedia/include/pjmedia-codec/vpx_packetizer.h
+++ b/pjmedia/include/pjmedia-codec/vpx_packetizer.h
@@ -1,0 +1,123 @@
+/* 
+ * Copyright (C) 2020 Teluu Inc. (http://www.teluu.com)
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA 
+ */
+#ifndef __PJMEDIA_VPX_PACKETIZER_H__
+#define __PJMEDIA_VPX_PACKETIZER_H__
+
+/**
+ * @file vpx_packetizer.h
+ * @brief Packetizes VPX bitstream into RTP payload and vice versa.
+ */
+
+#include <pj/types.h>
+
+PJ_BEGIN_DECL
+
+/**
+ * Opaque declaration for VPX packetizer.
+ */
+typedef struct pjmedia_vpx_packetizer pjmedia_vpx_packetizer;
+
+
+/**
+ * VPX packetizer setting.
+ */
+typedef struct pjmedia_vpx_packetizer_cfg
+{
+    /**
+     * VPX format id.
+     * Default: PJMEDIA_FORMAT_VP8
+     */
+    pj_uint32_t	fmt_id;
+
+    /**
+     * MTU size.
+     * Default: PJMEDIA_MAX_VID_PAYLOAD_SIZE
+     */
+    unsigned mtu;
+}
+pjmedia_vpx_packetizer_cfg;
+
+/**
+ * Use this function to initialize VPX packetizer config.
+ *
+ * @param cfg	The VPX packetizer config to be initialized.
+ */
+PJ_DECL(void) pjmedia_vpx_packetizer_cfg_default(
+					    pjmedia_vpx_packetizer_cfg *cfg);
+
+
+/**
+ * Create VPX packetizer.
+ *
+ * @param pool		The memory pool.
+ * @param cfg		Packetizer settings, if NULL, default setting
+ *			will be used.
+ * @param p_pktz	Pointer to receive the packetizer.
+ *
+ * @return		PJ_SUCCESS on success.
+ */
+PJ_DECL(pj_status_t) pjmedia_vpx_packetizer_create(
+				    pj_pool_t *pool,
+				    const pjmedia_vpx_packetizer_cfg *cfg,
+				    pjmedia_vpx_packetizer **p_pktz);
+
+
+/**
+ * Generate an RTP payload from a VPX picture bitstream. Note that this
+ * function will apply in-place processing, so the bitstream may be modified
+ * during the packetization.
+ *
+ * @param pktz		The packetizer.
+ * @param bits_len	The length of the bitstream.
+ * @param bits_pos	The bitstream offset to be packetized.
+ * @param is_keyframe	The frame is keyframe.
+ * @param payload	The output payload.
+ * @param payload_len	The output payload length, on input it represents max
+ *                      payload length.
+ *
+ * @return		PJ_SUCCESS on success.
+ */
+PJ_DECL(pj_status_t) pjmedia_vpx_packetize(const pjmedia_vpx_packetizer *pktz,
+					   pj_size_t bits_len,
+                                           unsigned *bits_pos,
+                                           pj_bool_t is_keyframe,
+                                           pj_uint8_t **payload,
+                                           pj_size_t *payload_len);
+
+
+/**
+ * Append an RTP payload to an VPX picture bitstream. Note that in case of
+ * noticing packet lost, application should keep calling this function with
+ * payload pointer set to NULL, as the packetizer need to update its internal
+ * state.
+ *
+ * @param pktz		    The packetizer.
+ * @param payload	    The payload to be unpacketized.
+ * @param payload_len	    The payload length.
+ * @param payload_desc_len  The payload description length.
+ *
+ * @return		    PJ_SUCCESS on success.
+ */
+PJ_DECL(pj_status_t) pjmedia_vpx_unpacketize(pjmedia_vpx_packetizer *pktz,
+					     const pj_uint8_t *payload,
+                                             pj_size_t payload_len,
+					     unsigned  *payload_desc_len);
+
+PJ_END_DECL
+
+#endif	/* __PJMEDIA_VPX_PACKETIZER_H__ */

--- a/pjmedia/src/pjmedia-codec/and_aud_mediacodec.cpp
+++ b/pjmedia/src/pjmedia-codec/and_aud_mediacodec.cpp
@@ -1,0 +1,1376 @@
+/*
+ * Copyright (C)2020 Teluu Inc. (http://www.teluu.com)
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+#include <pjmedia-codec/and_aud_mediacodec.h>
+#include <pjmedia-codec/amr_sdp_match.h>
+#include <pjmedia/codec.h>
+#include <pjmedia/errno.h>
+#include <pjmedia/endpoint.h>
+#include <pjmedia/plc.h>
+#include <pjmedia/port.h>
+#include <pjmedia/silencedet.h>
+#include <pj/assert.h>
+#include <pj/log.h>
+#include <pj/math.h>
+#include <pj/pool.h>
+#include <pj/string.h>
+#include <pj/os.h>
+
+/*
+ * Only build this file if PJMEDIA_HAS_ANDROID_MEDIACODEC != 0
+ */
+#if defined(PJMEDIA_HAS_ANDROID_MEDIACODEC) && \
+            PJMEDIA_HAS_ANDROID_MEDIACODEC != 0
+
+/* Android AMediaCodec: */
+#include "media/NdkMediaCodec.h"
+
+#define THIS_FILE  "and_aud_mediacodec.cpp"
+
+#define AND_MEDIA_KEY_PCM_ENCODING       "pcm-encoding"
+#define AND_MEDIA_KEY_CHANNEL_COUNT      "channel-count"
+#define AND_MEDIA_KEY_SAMPLE_RATE        "sample-rate"
+#define AND_MEDIA_KEY_BITRATE            "bitrate"
+#define AND_MEDIA_KEY_MIME               "mime"
+
+#define CODEC_WAIT_RETRY 	10
+#define CODEC_THREAD_WAIT 	10
+/* Timeout until the buffer is ready in ms. */
+#define CODEC_DEQUEUE_TIMEOUT 	10
+
+/* Prototypes for Android MediaCodec codecs factory */
+static pj_status_t and_media_test_alloc(pjmedia_codec_factory *factory,
+					const pjmedia_codec_info *id );
+static pj_status_t and_media_default_attr(pjmedia_codec_factory *factory,
+					  const pjmedia_codec_info *id,
+					  pjmedia_codec_param *attr );
+static pj_status_t and_media_enum_codecs(pjmedia_codec_factory *factory,
+					 unsigned *count,
+					 pjmedia_codec_info codecs[]);
+static pj_status_t and_media_alloc_codec(pjmedia_codec_factory *factory,
+					 const pjmedia_codec_info *id,
+					 pjmedia_codec **p_codec);
+static pj_status_t and_media_dealloc_codec(pjmedia_codec_factory *factory,
+					   pjmedia_codec *codec );
+
+/* Prototypes for Android MediaCodec codecs implementation. */
+static pj_status_t  and_media_codec_init(pjmedia_codec *codec,
+					 pj_pool_t *pool );
+static pj_status_t  and_media_codec_open(pjmedia_codec *codec,
+					 pjmedia_codec_param *attr );
+static pj_status_t  and_media_codec_close(pjmedia_codec *codec );
+static pj_status_t  and_media_codec_modify(pjmedia_codec *codec,
+					   const pjmedia_codec_param *attr );
+static pj_status_t  and_media_codec_parse(pjmedia_codec *codec,
+					  void *pkt,
+					  pj_size_t pkt_size,
+					  const pj_timestamp *ts,
+					  unsigned *frame_cnt,
+					  pjmedia_frame frames[]);
+static pj_status_t  and_media_codec_encode(pjmedia_codec *codec,
+					   const struct pjmedia_frame *input,
+					   unsigned output_buf_len,
+					   struct pjmedia_frame *output);
+static pj_status_t  and_media_codec_decode(pjmedia_codec *codec,
+					   const struct pjmedia_frame *input,
+					   unsigned output_buf_len,
+					   struct pjmedia_frame *output);
+static pj_status_t  and_media_codec_recover(pjmedia_codec *codec,
+					    unsigned output_buf_len,
+					    struct pjmedia_frame *output);
+
+/* Definition for Android MediaCodec codecs operations. */
+static pjmedia_codec_op and_media_op =
+{
+    &and_media_codec_init,
+    &and_media_codec_open,
+    &and_media_codec_close,
+    &and_media_codec_modify,
+    &and_media_codec_parse,
+    &and_media_codec_encode,
+    &and_media_codec_decode,
+    &and_media_codec_recover
+};
+
+/* Definition for Android MediaCodec codecs factory operations. */
+static pjmedia_codec_factory_op and_media_factory_op =
+{
+    &and_media_test_alloc,
+    &and_media_default_attr,
+    &and_media_enum_codecs,
+    &and_media_alloc_codec,
+    &and_media_dealloc_codec,
+    &pjmedia_codec_and_media_aud_deinit
+};
+
+/* Android MediaCodec codecs factory */
+static struct and_media_factory {
+    pjmedia_codec_factory    base;
+    pjmedia_endpt	    *endpt;
+    pj_pool_t		    *pool;
+    pj_mutex_t        	    *mutex;
+} and_media_factory;
+
+typedef enum and_aud_codec_id {
+    /* AMRNB codec. */
+    AND_AUD_CODEC_AMRNB,
+
+    /* AMRWB codec. */
+    AND_AUD_CODEC_AMRWB
+} and_aud_codec_id;
+
+/* Android MediaCodec codecs private data. */
+typedef struct and_media_private {
+    int			 codec_idx;	    /**< Codec index.		    */
+    void		*codec_setting;	    /**< Specific codec setting.    */
+    pj_pool_t		*pool;		    /**< Pool for each instance.    */
+    AMediaCodec         *enc;               /**< Encoder state.		    */
+    AMediaCodec         *dec;               /**< Decoder state.		    */
+
+    pj_uint16_t		 frame_size;	    /**< Bitstream frame size.	    */
+
+    pj_bool_t		 plc_enabled;	    /**< PLC enabled flag.	    */
+    pjmedia_plc		*plc;		    /**< PJMEDIA PLC engine, NULL if 
+						 codec has internal PLC.    */
+
+    pj_bool_t		 vad_enabled;	    /**< VAD enabled flag.	    */
+    pjmedia_silence_det	*vad;		    /**< PJMEDIA VAD engine, NULL if 
+						 codec has internal VAD.    */
+    pj_timestamp	 last_tx;	    /**< Timestamp of last transmit.*/
+} and_media_private_t;
+
+/* CUSTOM CALLBACKS */
+
+/* Parse frames from a packet. Default behaviour of frame parsing is 
+ * just separating frames based on calculating frame length derived 
+ * from bitrate. Implement this callback when the default behaviour is 
+ * unapplicable.
+ */
+typedef pj_status_t (*parse_cb)(and_media_private_t *codec_data, void *pkt,
+				pj_size_t pkt_size, const pj_timestamp *ts,
+				unsigned *frame_cnt, pjmedia_frame frames[]);
+
+/* Pack frames into a packet. Default behaviour of packing frames is 
+ * just stacking the frames with octet aligned without adding any 
+ * payload header. Implement this callback when the default behaviour is
+ * unapplicable.
+ */
+typedef pj_status_t (*pack_cb)(and_media_private_t *codec_data,
+			       unsigned nframes, void *pkt, pj_size_t *pkt_size,
+			       pj_size_t max_pkt_size);
+
+/* This callback is useful for preparing a frame before pass it to decoder.
+ */
+typedef void (*predecode_cb)(and_media_private_t  *codec_data,
+			     const pjmedia_frame *rtp_frame,
+			     pjmedia_frame *out);
+
+#if PJMEDIA_HAS_AND_MEDIA_AMRNB || PJMEDIA_HAS_AND_MEDIA_AMRWB
+/* Custom callback implementations. */
+static pj_status_t parse_amr(and_media_private_t *codec_data, void *pkt,
+			     pj_size_t pkt_size, const pj_timestamp *ts,
+			     unsigned *frame_cnt, pjmedia_frame frames[]);
+static  pj_status_t pack_amr(and_media_private_t *codec_data, unsigned nframes,
+			     void *pkt, pj_size_t *pkt_size,
+			     pj_size_t max_pkt_size);
+static void predecode_amr(and_media_private_t  *codec_data,
+			  const pjmedia_frame *input,
+			  pjmedia_frame *out);
+#endif
+
+#if PJMEDIA_HAS_AND_MEDIA_AMRNB
+
+static pj_str_t AMRNB_encoder[] = {{(char *)"OMX.google.amrnb.encoder\0", 24},
+				   {(char *)"c2.android.amrnb.encoder\0", 24}};
+
+static pj_str_t AMRNB_decoder[] = {{(char *)"OMX.google.amrnb.decoder\0", 24},
+			           {(char *)"c2.android.amrnb.decoder\0", 24}};
+#endif
+
+#if PJMEDIA_HAS_AND_MEDIA_AMRWB
+
+static pj_str_t AMRWB_encoder[] = {{(char *)"OMX.google.amrwb.encoder\0", 24},
+				   {(char *)"c2.android.amrwb.encoder\0", 24}};
+
+static pj_str_t AMRWB_decoder[] = {{(char *)"OMX.google.amrwb.decoder\0", 24},
+				   {(char *)"c2.android.amrwb.decoder\0", 24}};
+#endif
+
+/* Android MediaCodec codec implementation descriptions. */
+static struct and_media_codec {
+    int		     enabled;		/* Is this codec enabled?	    */
+    const char	    *name;		/* Codec name.			    */
+    const char      *mime_type;         /* Mime type.                       */
+    pj_str_t        *encoder_name;      /* Encoder name.                    */
+    pj_str_t        *decoder_name;      /* Decoder name.                    */
+
+    pj_uint8_t	     pt;		/* Payload type.		    */
+    and_aud_codec_id codec_id;		/* Codec id.                        */
+    unsigned	     clock_rate;	/* Codec's clock rate.		    */
+    unsigned	     channel_count;	/* Codec's channel count.	    */
+    unsigned	     samples_per_frame;	/* Codec's samples count.	    */
+    unsigned	     def_bitrate;	/* Default bitrate of this codec.   */
+    unsigned	     max_bitrate;	/* Maximum bitrate of this codec.   */
+    pj_uint8_t	     frm_per_pkt;	/* Default num of frames per packet.*/
+    int		     has_native_vad;	/* Codec has internal VAD?	    */
+    int		     has_native_plc;	/* Codec has internal PLC?	    */
+
+    parse_cb	     parse;		/* Callback to parse bitstream.	    */
+    pack_cb	     pack;		/* Callback to pack bitstream.	    */
+    predecode_cb     predecode;         /* Callback to prepare bitstream
+                                           before passing it to decoder.    */
+
+    pjmedia_codec_fmtp dec_fmtp;	/* Decoder's fmtp params.	    */
+}
+
+and_media_codec[] =
+{
+#   if PJMEDIA_HAS_AND_MEDIA_AMRNB
+    {0, "AMR", "audio/3gpp", NULL, NULL,
+        PJMEDIA_RTP_PT_AMR, AND_AUD_CODEC_AMRNB, 8000, 1, 160, 7400, 12200,
+        2, 0, 0, &parse_amr, &pack_amr, &predecode_amr,
+        {1, {{{(char *)"octet-align", 11}, {(char *)"1", 1}}}}
+    },
+#   endif
+
+#   if PJMEDIA_HAS_AND_MEDIA_AMRWB
+    {0, "AMR-WB", "audio/amr-wb", NULL, NULL,
+        PJMEDIA_RTP_PT_AMRWB, AND_AUD_CODEC_AMRWB, 16000, 1, 320, 15850, 23850,
+        2, 0, 0, &parse_amr, &pack_amr, &predecode_amr,
+	{1, {{{(char *)"octet-align", 11}, {(char *)"1", 1}}}}
+    },
+#   endif
+};
+
+#if PJMEDIA_HAS_AND_MEDIA_AMRNB || PJMEDIA_HAS_AND_MEDIA_AMRWB
+
+#include <pjmedia-codec/amr_helper.h>
+
+typedef struct amr_settings_t {
+    pjmedia_codec_amr_pack_setting enc_setting;
+    pjmedia_codec_amr_pack_setting dec_setting;
+    pj_int8_t enc_mode;
+} amr_settings_t;
+
+/* Pack AMR payload */
+static pj_status_t pack_amr(and_media_private_t *codec_data, unsigned nframes,
+			    void *pkt, pj_size_t *pkt_size,
+			    pj_size_t max_pkt_size)
+{
+    enum {MAX_FRAMES_PER_PACKET = PJMEDIA_MAX_FRAME_DURATION_MS / 20};
+
+    pjmedia_frame frames[MAX_FRAMES_PER_PACKET];
+    pj_uint8_t *p; /* Read cursor */
+    pjmedia_codec_amr_pack_setting *setting;
+    unsigned i;
+    pj_status_t status;
+
+    setting = &((amr_settings_t*)codec_data->codec_setting)->enc_setting;
+
+    /* Align pkt buf right */
+    p = (pj_uint8_t*)pkt + max_pkt_size - *pkt_size;
+    pj_memmove(p, pkt, *pkt_size);
+
+    /* Get frames */
+    for (i = 0; i < nframes; ++i) {
+	pjmedia_codec_amr_bit_info *info = (pjmedia_codec_amr_bit_info*)
+					    &frames[i].bit_info;
+	pj_bzero(info, sizeof(*info));
+	info->frame_type = (pj_uint8_t)((*p >> 3) & 0x0F);
+	info->good_quality = (pj_uint8_t)((*p >> 2) & 0x01);
+	info->mode = ((amr_settings_t*)codec_data->codec_setting)->enc_mode;
+	info->start_bit = 0;
+	frames[i].buf = p + 1;
+        if (setting->amr_nb) {
+            frames[i].size = (info->frame_type <= 8)?
+                             pjmedia_codec_amrnb_framelen[info->frame_type] : 0;
+        } else {
+            frames[i].size = (info->frame_type <= 9)?
+                             pjmedia_codec_amrwb_framelen[info->frame_type] : 0;
+        }
+	p += frames[i].size + 1;
+    }
+    /* Pack */
+    *pkt_size = max_pkt_size;
+    status = pjmedia_codec_amr_pack(frames, nframes, setting, pkt, pkt_size);
+
+    return status;
+}
+
+/* Parse AMR payload into frames. */
+static pj_status_t parse_amr(and_media_private_t *codec_data, void *pkt,
+			     pj_size_t pkt_size, const pj_timestamp *ts,
+			     unsigned *frame_cnt, pjmedia_frame frames[])
+{
+    amr_settings_t* s = (amr_settings_t*)codec_data->codec_setting;
+    pjmedia_codec_amr_pack_setting *setting;
+    pj_status_t status;
+    pj_uint8_t cmr;
+
+    setting = &s->dec_setting;
+    status = pjmedia_codec_amr_parse(pkt, pkt_size, ts, setting, frames, 
+				     frame_cnt, &cmr);
+    if (status != PJ_SUCCESS)
+	return status;
+
+    /* Check Change Mode Request. */
+    if (((setting->amr_nb && cmr <= 7) || (!setting->amr_nb && cmr <= 8)) &&
+	s->enc_mode != cmr)
+    {
+	s->enc_mode = cmr;
+    }
+    return PJ_SUCCESS;
+}
+
+static void predecode_amr(and_media_private_t *codec_data,
+			  const pjmedia_frame *input,
+			  pjmedia_frame *out)
+{
+    pjmedia_codec_amr_bit_info *info;
+    pj_uint8_t *bitstream = (pj_uint8_t *)out->buf;
+    pjmedia_codec_amr_pack_setting *setting;
+
+    out->buf = &bitstream[1];
+    setting = &((amr_settings_t*)codec_data->codec_setting)->dec_setting;
+    pjmedia_codec_amr_predecode(input, setting, out);
+    info = (pjmedia_codec_amr_bit_info*)&out->bit_info;
+    bitstream[0] = (info->frame_type << 3) | (info->good_quality << 2);
+    out->buf = &bitstream[0];
+    ++out->size;
+}
+
+#endif /* PJMEDIA_HAS_AND_MEDIA_AMRNB || PJMEDIA_HAS_AND_MEDIA_AMRWB */
+
+static pj_status_t configure_codec(and_media_private_t *and_media_data,
+				   pj_bool_t is_encoder)
+{
+    media_status_t am_status;
+    AMediaFormat *aud_fmt;
+    int idx = and_media_data->codec_idx;
+    AMediaCodec *codec = (is_encoder?and_media_data->enc:and_media_data->dec);
+
+    aud_fmt = AMediaFormat_new();
+    if (!aud_fmt) {
+        return PJ_ENOMEM;
+    }
+    AMediaFormat_setString(aud_fmt, AND_MEDIA_KEY_MIME,
+                           and_media_codec[idx].mime_type);
+    AMediaFormat_setInt32(aud_fmt, AND_MEDIA_KEY_PCM_ENCODING, 2);
+    AMediaFormat_setInt32(aud_fmt, AND_MEDIA_KEY_CHANNEL_COUNT,
+                          and_media_codec[idx].channel_count);
+    AMediaFormat_setInt32(aud_fmt, AND_MEDIA_KEY_SAMPLE_RATE,
+			  and_media_codec[idx].clock_rate);
+    AMediaFormat_setInt32(aud_fmt, AND_MEDIA_KEY_BITRATE,
+			  and_media_codec[idx].def_bitrate);
+
+    /* Configure and start encoder. */
+    am_status = AMediaCodec_configure(codec, aud_fmt, NULL, NULL, is_encoder);
+    AMediaFormat_delete(aud_fmt);
+    if (am_status != AMEDIA_OK) {
+        PJ_LOG(4, (THIS_FILE, "%s [0x%x] configure failed, status=%d",
+               is_encoder?"Encoder":"Decoder", codec, am_status));
+        return PJMEDIA_CODEC_EFAILED;
+    }
+    am_status = AMediaCodec_start(codec);
+    if (am_status != AMEDIA_OK) {
+	PJ_LOG(4, (THIS_FILE, "%s [0x%x] start failed, status=%d",
+	       is_encoder?"Encoder":"Decoder", codec, am_status));
+	return PJMEDIA_CODEC_EFAILED;
+    }
+    PJ_LOG(4, (THIS_FILE, "%s [0x%x] started", is_encoder?"Encoder":"Decoder",
+	   codec));
+    return PJ_SUCCESS;
+}
+
+/*
+ * Initialize and register Android MediaCodec codec factory to pjmedia endpoint.
+ */
+PJ_DEF(pj_status_t) pjmedia_codec_and_media_aud_init( pjmedia_endpt *endpt )
+{
+    pjmedia_codec_mgr *codec_mgr;
+    pj_str_t codec_name;
+    pj_status_t status;
+
+    if (and_media_factory.pool != NULL) {
+	/* Already initialized. */
+	return PJ_SUCCESS;
+    }
+
+    PJ_LOG(4, (THIS_FILE, "Initing codec"));
+
+    /* Create Android MediaCodec codec factory. */
+    and_media_factory.base.op = &and_media_factory_op;
+    and_media_factory.base.factory_data = NULL;
+    and_media_factory.endpt = endpt;
+
+    and_media_factory.pool = pjmedia_endpt_create_pool(endpt,
+                                                   "Android MediaCodec codecs",
+                                                   4000, 4000);
+    if (!and_media_factory.pool)
+	return PJ_ENOMEM;
+
+    /* Create mutex. */
+    status = pj_mutex_create_simple(and_media_factory.pool,
+                                    "Android MediaCodec codecs",
+				    &and_media_factory.mutex);
+    if (status != PJ_SUCCESS)
+	goto on_error;
+
+    /* Get the codec manager. */
+    codec_mgr = pjmedia_endpt_get_codec_mgr(endpt);
+    if (!codec_mgr) {
+	status = PJ_EINVALIDOP;
+	goto on_error;
+    }
+
+#if PJMEDIA_HAS_AND_MEDIA_AMRNB
+    PJ_LOG(4, (THIS_FILE, "Registering AMRNB codec"));
+
+    pj_cstr(&codec_name, "AMR");
+    status = pjmedia_sdp_neg_register_fmt_match_cb(
+						&codec_name,
+						&pjmedia_codec_amr_match_sdp);
+    if (status != PJ_SUCCESS)
+	goto on_error;
+#endif
+
+#if PJMEDIA_HAS_AND_MEDIA_AMRWB
+    PJ_LOG(4, (THIS_FILE, "Registering AMRWB codec"));
+
+    pj_cstr(&codec_name, "AMR-WB");
+    status = pjmedia_sdp_neg_register_fmt_match_cb(
+						&codec_name,
+						&pjmedia_codec_amr_match_sdp);
+    if (status != PJ_SUCCESS)
+	goto on_error;
+#endif
+
+    /* Suppress compile warning */
+    PJ_UNUSED_ARG(codec_name);
+
+    /* Register codec factory to endpoint. */
+    status = pjmedia_codec_mgr_register_factory(codec_mgr, 
+						&and_media_factory.base);
+    if (status != PJ_SUCCESS)
+	goto on_error;
+
+    /* Done. */
+    return PJ_SUCCESS;
+
+on_error:
+    pj_pool_release(and_media_factory.pool);
+    and_media_factory.pool = NULL;
+    return status;
+}
+
+/*
+ * Unregister Android MediaCodec codecs factory from pjmedia endpoint.
+ */
+PJ_DEF(pj_status_t) pjmedia_codec_and_media_aud_deinit(void)
+{
+    pjmedia_codec_mgr *codec_mgr;
+    pj_status_t status;
+
+    if (and_media_factory.pool == NULL) {
+	/* Already deinitialized */
+	return PJ_SUCCESS;
+    }
+
+    pj_mutex_lock(and_media_factory.mutex);
+
+    /* Get the codec manager. */
+    codec_mgr = pjmedia_endpt_get_codec_mgr(and_media_factory.endpt);
+    if (!codec_mgr) {
+	pj_pool_release(and_media_factory.pool);
+	and_media_factory.pool = NULL;
+	pj_mutex_unlock(and_media_factory.mutex);
+	return PJ_EINVALIDOP;
+    }
+
+    /* Unregister Android MediaCodec codecs factory. */
+    status = pjmedia_codec_mgr_unregister_factory(codec_mgr,
+						  &and_media_factory.base);
+
+    /* Destroy mutex. */
+    pj_mutex_unlock(and_media_factory.mutex);
+    pj_mutex_destroy(and_media_factory.mutex);
+    and_media_factory.mutex = NULL;
+
+    /* Destroy pool. */
+    pj_pool_release(and_media_factory.pool);
+    and_media_factory.pool = NULL;
+
+    return status;
+}
+
+/*
+ * Check if factory can allocate the specified codec. 
+ */
+static pj_status_t and_media_test_alloc(pjmedia_codec_factory *factory,
+					const pjmedia_codec_info *info )
+{
+    unsigned i;
+
+    PJ_UNUSED_ARG(factory);
+
+    /* Type MUST be audio. */
+    if (info->type != PJMEDIA_TYPE_AUDIO)
+	return PJMEDIA_CODEC_EUNSUP;
+
+    for (i = 0; i < PJ_ARRAY_SIZE(and_media_codec); ++i) {
+	pj_str_t name = pj_str((char*)and_media_codec[i].name);
+	if ((pj_stricmp(&info->encoding_name, &name) == 0) &&
+	    (info->clock_rate == (unsigned)and_media_codec[i].clock_rate) &&
+	    (info->channel_cnt == (unsigned)and_media_codec[i].channel_count) &&
+	    (and_media_codec[i].enabled))
+	{
+	    return PJ_SUCCESS;
+	}
+    }
+
+    /* Unsupported, or mode is disabled. */
+    return PJMEDIA_CODEC_EUNSUP;
+}
+
+/*
+ * Generate default attribute.
+ */
+static pj_status_t and_media_default_attr (pjmedia_codec_factory *factory,
+					   const pjmedia_codec_info *id,
+					   pjmedia_codec_param *attr)
+{
+    unsigned i;
+
+    PJ_ASSERT_RETURN(factory==&and_media_factory.base, PJ_EINVAL);
+
+    pj_bzero(attr, sizeof(pjmedia_codec_param));
+
+    for (i = 0; i < PJ_ARRAY_SIZE(and_media_codec); ++i) {
+	pj_str_t name = pj_str((char*)and_media_codec[i].name);
+	if ((and_media_codec[i].enabled) &&
+	    (pj_stricmp(&id->encoding_name, &name) == 0) &&
+	    (id->clock_rate == (unsigned)and_media_codec[i].clock_rate) &&
+	    (id->channel_cnt == (unsigned)and_media_codec[i].channel_count) &&
+	    (id->pt == (unsigned)and_media_codec[i].pt))
+	{
+	    attr->info.pt = (pj_uint8_t)id->pt;
+	    attr->info.channel_cnt = and_media_codec[i].channel_count;
+	    attr->info.clock_rate = and_media_codec[i].clock_rate;
+	    attr->info.avg_bps = and_media_codec[i].def_bitrate;
+	    attr->info.max_bps = and_media_codec[i].max_bitrate;
+	    attr->info.pcm_bits_per_sample = 16;
+	    attr->info.frm_ptime =  (pj_uint16_t)
+				(and_media_codec[i].samples_per_frame * 1000 /
+				and_media_codec[i].channel_count /
+				and_media_codec[i].clock_rate);
+	    attr->setting.frm_per_pkt = and_media_codec[i].frm_per_pkt;
+
+	    /* Default flags. */
+	    attr->setting.plc = 1;
+	    attr->setting.penh= 0;
+	    attr->setting.vad = 1;
+	    attr->setting.cng = attr->setting.vad;
+	    attr->setting.dec_fmtp = and_media_codec[i].dec_fmtp;
+
+	    return PJ_SUCCESS;
+	}
+    }
+
+    return PJMEDIA_CODEC_EUNSUP;
+}
+
+static pj_bool_t codec_exists(const pj_str_t *codec_name)
+{
+    AMediaCodec *codec;
+    char *codec_txt;
+
+    codec_txt = codec_name->ptr;
+
+    codec = AMediaCodec_createCodecByName(codec_txt);
+    if (!codec) {
+	PJ_LOG(4, (THIS_FILE, "Failed creating codec : %.*s", codec_name->slen,
+		   codec_name->ptr));
+	return PJ_FALSE;
+    }
+    AMediaCodec_delete(codec);
+
+    return PJ_TRUE;
+}
+
+/*
+ * Enum codecs supported by this factory.
+ */
+static pj_status_t and_media_enum_codecs(pjmedia_codec_factory *factory,
+					 unsigned *count,
+					 pjmedia_codec_info codecs[])
+{
+    unsigned max;
+    unsigned i;
+
+    PJ_UNUSED_ARG(factory);
+    PJ_ASSERT_RETURN(codecs && *count > 0, PJ_EINVAL);
+
+    max = *count;
+
+    for (i = 0, *count = 0; i < PJ_ARRAY_SIZE(and_media_codec) &&
+         *count < max; ++i)
+    {
+	unsigned enc_idx, dec_idx;
+	pj_str_t *enc_name = NULL;
+	unsigned num_enc = 0;
+	pj_str_t *dec_name = NULL;
+	unsigned num_dec = 0;
+
+	switch (and_media_codec[i].codec_id) {
+
+	case AND_AUD_CODEC_AMRNB:
+#if PJMEDIA_HAS_AND_MEDIA_AMRNB
+	    enc_name = &AMRNB_encoder[0];
+	    dec_name = &AMRNB_decoder[0];
+	    num_enc = PJ_ARRAY_SIZE(AMRNB_encoder);
+	    num_dec = PJ_ARRAY_SIZE(AMRNB_decoder);
+#endif
+	    break;
+	case AND_AUD_CODEC_AMRWB:
+#if PJMEDIA_HAS_AND_MEDIA_AMRWB
+	    enc_name = &AMRWB_encoder[0];
+	    dec_name = &AMRWB_decoder[0];
+	    num_enc = PJ_ARRAY_SIZE(AMRWB_encoder);
+	    num_dec = PJ_ARRAY_SIZE(AMRWB_decoder);
+#endif
+
+	    break;
+	default:
+	    continue;
+	};
+	if (!enc_name || !dec_name) {
+	    continue;
+	}
+
+	for (enc_idx = 0; enc_idx < num_enc ;++enc_idx, ++enc_name) {
+	    if (codec_exists(enc_name)) {
+		break;
+	    }
+	}
+	if (enc_idx == num_enc)
+	    continue;
+
+	for (dec_idx = 0; dec_idx < num_dec ;++dec_idx, ++dec_name) {
+	    if (codec_exists(dec_name)) {
+		break;
+	    }
+	}
+	if (dec_idx == num_dec)
+	    continue;
+
+	and_media_codec[i].encoder_name = enc_name;
+	and_media_codec[i].decoder_name = dec_name;
+	pj_bzero(&codecs[*count], sizeof(pjmedia_codec_info));
+	codecs[*count].encoding_name = pj_str((char*)and_media_codec[i].name);
+	codecs[*count].pt = and_media_codec[i].pt;
+	codecs[*count].type = PJMEDIA_TYPE_AUDIO;
+	codecs[*count].clock_rate = and_media_codec[i].clock_rate;
+	codecs[*count].channel_cnt = and_media_codec[i].channel_count;
+	and_media_codec[i].enabled = PJ_TRUE;
+	PJ_LOG(4, (THIS_FILE, "Found encoder [%d]: %.*s and decoder: %.*s ",
+		   *count, enc_name->slen, enc_name->ptr, dec_name->slen,
+		   dec_name->ptr));
+	++*count;
+    }
+
+    return PJ_SUCCESS;
+}
+
+static void create_codec(and_media_private_t *and_media_data)
+{
+    char const *enc_name =
+		   and_media_codec[and_media_data->codec_idx].encoder_name->ptr;
+    char const *dec_name =
+		   and_media_codec[and_media_data->codec_idx].decoder_name->ptr;
+
+    if (!and_media_data->enc) {
+	and_media_data->enc = AMediaCodec_createCodecByName(enc_name);
+	if (!and_media_data->enc) {
+	    PJ_LOG(4, (THIS_FILE, "Failed creating encoder: %s", enc_name));
+	}
+	PJ_LOG(4, (THIS_FILE, "Done creating encoder: %s [0x%x]", enc_name,
+	       and_media_data->enc));
+    }
+
+    if (!and_media_data->dec) {
+	and_media_data->dec = AMediaCodec_createCodecByName(dec_name);
+	if (!and_media_data->dec) {
+	    PJ_LOG(4, (THIS_FILE, "Failed creating decoder: %s", dec_name));
+	}
+	PJ_LOG(4, (THIS_FILE, "Done creating decoder: %s [0x%x]", dec_name,
+	       and_media_data->dec));
+    }
+}
+
+/*
+ * Allocate a new codec instance.
+ */
+static pj_status_t and_media_alloc_codec(pjmedia_codec_factory *factory,
+					 const pjmedia_codec_info *id,
+					 pjmedia_codec **p_codec)
+{
+    and_media_private_t *codec_data;
+    pjmedia_codec *codec;
+    int idx;
+    pj_pool_t *pool;
+    unsigned i;
+
+    PJ_ASSERT_RETURN(factory && id && p_codec, PJ_EINVAL);
+    PJ_ASSERT_RETURN(factory == &and_media_factory.base, PJ_EINVAL);
+
+    pj_mutex_lock(and_media_factory.mutex);
+
+    /* Find codec's index */
+    idx = -1;
+    for (i = 0; i < PJ_ARRAY_SIZE(and_media_codec); ++i) {
+	pj_str_t name = pj_str((char*)and_media_codec[i].name);
+	if ((pj_stricmp(&id->encoding_name, &name) == 0) &&
+	    (id->clock_rate == (unsigned)and_media_codec[i].clock_rate) &&
+	    (id->channel_cnt == (unsigned)and_media_codec[i].channel_count) &&
+	    (and_media_codec[i].enabled))
+	{
+	    idx = i;
+	    break;
+	}
+    }
+    if (idx == -1) {
+	*p_codec = NULL;
+	return PJMEDIA_CODEC_EFAILED;
+    }
+
+    /* Create pool for codec instance */
+    pool = pjmedia_endpt_create_pool(and_media_factory.endpt, "andmedaud%p",
+                                     512, 512);
+    codec = PJ_POOL_ZALLOC_T(pool, pjmedia_codec);
+    PJ_ASSERT_RETURN(codec != NULL, PJ_ENOMEM);
+    codec->op = &and_media_op;
+    codec->factory = factory;
+    codec->codec_data = PJ_POOL_ZALLOC_T(pool, and_media_private_t);
+    codec_data = (and_media_private_t*) codec->codec_data;
+
+    /* Create PLC if codec has no internal PLC */
+    if (!and_media_codec[idx].has_native_plc) {
+	pj_status_t status;
+	status = pjmedia_plc_create(pool, and_media_codec[idx].clock_rate,
+				    and_media_codec[idx].samples_per_frame, 0,
+				    &codec_data->plc);
+	if (status != PJ_SUCCESS) {
+	    goto on_error;
+	}
+    }
+
+    /* Create silence detector if codec has no internal VAD */
+    if (!and_media_codec[idx].has_native_vad) {
+	pj_status_t status;
+	status = pjmedia_silence_det_create(pool,
+					and_media_codec[idx].clock_rate,
+					and_media_codec[idx].samples_per_frame,
+					&codec_data->vad);
+	if (status != PJ_SUCCESS) {
+	    goto on_error;
+	}
+    }
+
+    codec_data->pool = pool;
+    codec_data->codec_idx = idx;
+
+    create_codec(codec_data);
+    if (!codec_data->enc || !codec_data->dec) {
+	goto on_error;
+    }
+    pj_mutex_unlock(and_media_factory.mutex);
+
+    *p_codec = codec;
+    return PJ_SUCCESS;
+
+on_error:
+    pj_mutex_unlock(and_media_factory.mutex);
+    and_media_dealloc_codec(factory, codec);
+    return PJMEDIA_CODEC_EFAILED;
+}
+
+/*
+ * Free codec.
+ */
+static pj_status_t and_media_dealloc_codec(pjmedia_codec_factory *factory,
+					   pjmedia_codec *codec )
+{
+    and_media_private_t *codec_data;
+
+    PJ_ASSERT_RETURN(factory && codec, PJ_EINVAL);
+    PJ_ASSERT_RETURN(factory == &and_media_factory.base, PJ_EINVAL);
+
+    /* Close codec, if it's not closed. */
+    codec_data = (and_media_private_t*) codec->codec_data;
+    if (codec_data->enc) {
+        AMediaCodec_stop(codec_data->enc);
+        AMediaCodec_delete(codec_data->enc);
+        codec_data->enc = NULL;
+    }
+
+    if (codec_data->dec) {
+        AMediaCodec_stop(codec_data->dec);
+        AMediaCodec_delete(codec_data->dec);
+        codec_data->dec = NULL;
+    }
+    pj_pool_release(codec_data->pool);
+
+    return PJ_SUCCESS;
+}
+
+/*
+ * Init codec.
+ */
+static pj_status_t and_media_codec_init(pjmedia_codec *codec,
+				        pj_pool_t *pool )
+{
+    PJ_UNUSED_ARG(codec);
+    PJ_UNUSED_ARG(pool);
+    return PJ_SUCCESS;
+}
+
+/*
+ * Open codec.
+ */
+static pj_status_t and_media_codec_open(pjmedia_codec *codec,
+					pjmedia_codec_param *attr)
+{
+    and_media_private_t *codec_data = (and_media_private_t*) codec->codec_data;
+    struct and_media_codec *and_media_data =
+					&and_media_codec[codec_data->codec_idx];
+    pj_status_t status;
+
+    PJ_ASSERT_RETURN(codec && attr, PJ_EINVAL);
+    PJ_ASSERT_RETURN(codec_data != NULL, PJ_EINVALIDOP);
+
+    PJ_LOG(5,(THIS_FILE, "Opening codec.."));
+
+    codec_data->vad_enabled = (attr->setting.vad != 0);
+    codec_data->plc_enabled = (attr->setting.plc != 0);
+    and_media_data->clock_rate = attr->info.clock_rate;
+
+#if PJMEDIA_HAS_AND_MEDIA_AMRNB
+    if (and_media_data->codec_id == AND_AUD_CODEC_AMRNB ||
+	and_media_data->codec_id == AND_AUD_CODEC_AMRWB)
+    {
+	amr_settings_t *s;
+	pj_uint8_t octet_align = 0;
+	pj_int8_t enc_mode;
+	unsigned i;
+
+	enc_mode = pjmedia_codec_amr_get_mode(attr->info.avg_bps);
+
+	pj_assert(enc_mode >= 0 && enc_mode <= 8);
+
+	/* Check AMR specific attributes */
+	for (i = 0; i < attr->setting.dec_fmtp.cnt; ++i) {
+	    /* octet-align, one of the parameters that must have same value
+	     * in offer & answer (RFC 4867 Section 8.3.1). Just check fmtp
+	     * in the decoder side, since it's value is guaranteed to fulfil
+	     * above requirement (by SDP negotiator).
+	     */
+	    const pj_str_t STR_FMTP_OCTET_ALIGN = {(char *)"octet-align", 11};
+
+	    if (pj_stricmp(&attr->setting.dec_fmtp.param[i].name,
+			   &STR_FMTP_OCTET_ALIGN) == 0)
+	    {
+		octet_align=(pj_uint8_t)
+			    pj_strtoul(&attr->setting.dec_fmtp.param[i].val);
+		break;
+	    }
+	}
+	for (i = 0; i < attr->setting.enc_fmtp.cnt; ++i) {
+	    /* mode-set, encoding mode is chosen based on local default mode
+	     * setting:
+	     * - if local default mode is included in the mode-set, use it
+	     * - otherwise, find the closest mode to local default mode;
+	     *   if there are two closest modes, prefer to use the higher
+	     *   one, e.g: local default mode is 4, the mode-set param
+	     *   contains '2,3,5,6', then 5 will be chosen.
+	     */
+	    const pj_str_t STR_FMTP_MODE_SET = {(char *)"mode-set", 8};
+
+	    if (pj_stricmp(&attr->setting.enc_fmtp.param[i].name,
+			   &STR_FMTP_MODE_SET) == 0)
+	    {
+		const char *p;
+		pj_size_t l;
+		pj_int8_t diff = 99;
+
+		p = pj_strbuf(&attr->setting.enc_fmtp.param[i].val);
+		l = pj_strlen(&attr->setting.enc_fmtp.param[i].val);
+
+		while (l--) {
+		    if ((and_media_data->codec_id == AND_AUD_CODEC_AMRNB &&
+			 *p>='0' && *p<='7') ||
+		        (and_media_data->codec_id == AND_AUD_CODEC_AMRWB &&
+		         *p>='0' && *p<='8'))
+		    {
+			pj_int8_t tmp = (pj_int8_t)(*p - '0' - enc_mode);
+
+			if (PJ_ABS(diff) > PJ_ABS(tmp) ||
+			    (PJ_ABS(diff) == PJ_ABS(tmp) && tmp > diff))
+			{
+			    diff = tmp;
+			    if (diff == 0) break;
+			}
+		    }
+		    ++p;
+		}
+		if (diff == 99)
+		    goto on_error;
+
+		enc_mode = (pj_int8_t)(enc_mode + diff);
+
+		break;
+	    }
+	}
+	/* Initialize AMR specific settings */
+	s = PJ_POOL_ZALLOC_T(codec_data->pool, amr_settings_t);
+	codec_data->codec_setting = s;
+
+	s->enc_setting.amr_nb = (pj_uint8_t)
+			      (and_media_data->codec_id == AND_AUD_CODEC_AMRNB);
+	s->enc_setting.octet_aligned = octet_align;
+	s->enc_setting.reorder = 0;
+	s->enc_setting.cmr = 15;
+	s->dec_setting.amr_nb = (pj_uint8_t)
+			      (and_media_data->codec_id == AND_AUD_CODEC_AMRNB);
+	s->dec_setting.octet_aligned = octet_align;
+	s->dec_setting.reorder = 0;
+	/* Apply encoder mode/bitrate */
+	s->enc_mode = enc_mode;
+
+	PJ_LOG(4, (THIS_FILE, "Encoder setting octet_aligned=%d reorder=%d"
+		   " cmr=%d enc_mode=%d",
+		   s->enc_setting.octet_aligned, s->enc_setting.reorder,
+		   s->enc_setting.cmr, enc_mode));
+	PJ_LOG(4, (THIS_FILE, "Decoder setting octet_aligned=%d reorder=%d",
+		   s->dec_setting.octet_aligned, s->dec_setting.reorder));
+    }
+#endif
+    status = configure_codec(codec_data, PJ_TRUE);
+    if (status != PJ_SUCCESS) {
+        goto on_error;
+    }
+    status = configure_codec(codec_data, PJ_FALSE);
+    if (status != PJ_SUCCESS) {
+	goto on_error;
+    }
+
+    return PJ_SUCCESS;
+
+on_error:
+    return PJMEDIA_CODEC_EFAILED;
+}
+
+/*
+ * Close codec.
+ */
+static pj_status_t and_media_codec_close(pjmedia_codec *codec)
+{
+    PJ_UNUSED_ARG(codec);
+
+    return PJ_SUCCESS;
+}
+
+/*
+ * Modify codec settings.
+ */
+static pj_status_t  and_media_codec_modify(pjmedia_codec *codec,
+					   const pjmedia_codec_param *attr)
+{
+    and_media_private_t *codec_data = (and_media_private_t*) codec->codec_data;
+
+    codec_data->vad_enabled = (attr->setting.vad != 0);
+    codec_data->plc_enabled = (attr->setting.plc != 0);
+
+    return PJ_SUCCESS;
+}
+
+/*
+ * Get frames in the packet.
+ */
+static pj_status_t and_media_codec_parse(pjmedia_codec *codec,
+					 void *pkt,
+					 pj_size_t pkt_size,
+					 const pj_timestamp *ts,
+					 unsigned *frame_cnt,
+					 pjmedia_frame frames[])
+{
+    and_media_private_t *codec_data = (and_media_private_t*) codec->codec_data;
+    struct and_media_codec *and_media_data =
+					&and_media_codec[codec_data->codec_idx];
+    unsigned count = 0;
+
+    PJ_ASSERT_RETURN(frame_cnt, PJ_EINVAL);
+
+    if (and_media_data->parse != NULL) {
+	return and_media_data->parse(codec_data, pkt,  pkt_size, ts, frame_cnt,
+				     frames);
+    }
+
+    while (pkt_size >= codec_data->frame_size && count < *frame_cnt) {
+	frames[count].type = PJMEDIA_FRAME_TYPE_AUDIO;
+	frames[count].buf = pkt;
+	frames[count].size = codec_data->frame_size;
+	frames[count].timestamp.u64 = ts->u64 +
+				      count*and_media_data->samples_per_frame;
+	pkt = ((char*)pkt) + codec_data->frame_size;
+	pkt_size -= codec_data->frame_size;
+	++count;
+    }
+
+    if (pkt_size && count < *frame_cnt) {
+	frames[count].type = PJMEDIA_FRAME_TYPE_AUDIO;
+	frames[count].buf = pkt;
+	frames[count].size = pkt_size;
+	frames[count].timestamp.u64 = ts->u64 +
+				      count*and_media_data->samples_per_frame;
+	++count;
+    }
+
+    *frame_cnt = count;
+    return PJ_SUCCESS;
+}
+
+/*
+ * Encode frames.
+ */
+static pj_status_t and_media_codec_encode(pjmedia_codec *codec,
+					  const struct pjmedia_frame *input,
+					  unsigned output_buf_len,
+					  struct pjmedia_frame *output)
+{
+    and_media_private_t *codec_data = (and_media_private_t*) codec->codec_data;
+    struct and_media_codec *and_media_data =
+					&and_media_codec[codec_data->codec_idx];
+    unsigned samples_per_frame;
+    unsigned nsamples;
+    unsigned nframes;
+    pj_size_t tx = 0;
+    pj_int16_t *pcm_in = (pj_int16_t*)input->buf;
+    pj_uint8_t  *bits_out = (pj_uint8_t*) output->buf;
+    pj_uint8_t pt;
+
+    /* Invoke external VAD if codec has no internal VAD */
+    if (codec_data->vad && codec_data->vad_enabled) {
+	pj_bool_t is_silence;
+	pj_int32_t silence_duration;
+
+	silence_duration = pj_timestamp_diff32(&codec_data->last_tx, 
+					       &input->timestamp);
+
+	is_silence = pjmedia_silence_det_detect(codec_data->vad, 
+					        (const pj_int16_t*) input->buf,
+						(input->size >> 1),
+						NULL);
+	if (is_silence &&
+	    (PJMEDIA_CODEC_MAX_SILENCE_PERIOD == -1 ||
+	     silence_duration < (PJMEDIA_CODEC_MAX_SILENCE_PERIOD *
+	 			 (int)and_media_data->clock_rate / 1000)))
+	{
+	    output->type = PJMEDIA_FRAME_TYPE_NONE;
+	    output->buf = NULL;
+	    output->size = 0;
+	    output->timestamp = input->timestamp;
+	    return PJ_SUCCESS;
+	} else {
+	    codec_data->last_tx = input->timestamp;
+	}
+    }
+    nsamples = input->size >> 1;
+    samples_per_frame = and_media_data->samples_per_frame;
+    pt = and_media_data->pt;
+    nframes = nsamples / samples_per_frame;
+
+    PJ_ASSERT_RETURN(nsamples % samples_per_frame == 0, 
+		     PJMEDIA_CODEC_EPCMFRMINLEN);
+
+    /* Encode the frames */
+    while (nsamples >= samples_per_frame) {
+        pj_ssize_t buf_idx;
+        unsigned i;
+        pj_size_t output_size;
+        pj_uint8_t *output_buf;
+        AMediaCodecBufferInfo buf_info;
+
+        buf_idx = AMediaCodec_dequeueInputBuffer(codec_data->enc,
+					         CODEC_DEQUEUE_TIMEOUT);
+
+        if (buf_idx >= 0) {
+	    media_status_t am_status;
+	    pj_size_t output_size;
+            unsigned input_size = samples_per_frame << 1;
+
+	    pj_uint8_t *input_buf = AMediaCodec_getInputBuffer(codec_data->enc,
+						        buf_idx, &output_size);
+
+	    if (input_buf && output_size >= input_size) {
+	        pj_memcpy(input_buf, pcm_in, input_size);
+
+	        am_status = AMediaCodec_queueInputBuffer(codec_data->enc,
+				                  buf_idx, 0, input_size, 0, 0);
+	        if (am_status != AMEDIA_OK) {
+		    PJ_LOG(4, (THIS_FILE, "Encoder queueInputBuffer return %d",
+		               am_status));
+		    goto on_return;
+	        }
+	    } else {
+	        if (!input_buf) {
+		    PJ_LOG(4,(THIS_FILE, "Encoder getInputBuffer "
+				         "returns no input buff"));
+	        } else {
+		    PJ_LOG(4,(THIS_FILE, "Encoder getInputBuffer "
+				         "size: %d, expecting %d.",
+				         input_buf, output_size, input_size));
+	        }
+	        goto on_return;
+	    }
+        } else {
+	    PJ_LOG(4,(THIS_FILE, "Encoder dequeueInputBuffer failed[%d]",
+                      buf_idx));
+	    goto on_return;
+        }
+
+        for (i = 0; i < CODEC_WAIT_RETRY; ++i) {
+	    buf_idx = AMediaCodec_dequeueOutputBuffer(codec_data->enc,
+						      &buf_info,
+						      CODEC_DEQUEUE_TIMEOUT);
+	    if (buf_idx == -1) {
+	        /* Timeout, wait until output buffer is availble. */
+	        pj_thread_sleep(CODEC_THREAD_WAIT);
+	    } else {
+	        break;
+	    }
+        }
+
+        if (buf_idx < 0) {
+	    PJ_LOG(4, (THIS_FILE, "Encoder dequeueOutputBuffer failed %d",
+		   buf_idx));
+            goto on_return;
+        }
+
+        output_buf = AMediaCodec_getOutputBuffer(codec_data->enc,
+                                                 buf_idx,
+                                                 &output_size);
+        if (!output_buf) {
+            PJ_LOG(4, (THIS_FILE, "Encoder failed getting output buffer, "
+                       "buffer size=%d, flags %d",
+                       buf_info.size, buf_info.flags));
+            goto on_return;
+        }
+
+        pj_memcpy(bits_out, output_buf, buf_info.size);
+        AMediaCodec_releaseOutputBuffer(codec_data->enc,
+                                        buf_idx,
+                                        0);
+        bits_out += buf_info.size;
+        tx += buf_info.size;
+	pcm_in += samples_per_frame;
+	nsamples -= samples_per_frame;
+    }
+    if (and_media_data->pack != NULL) {
+	and_media_data->pack(codec_data, nframes, output->buf, &tx,
+			     output_buf_len);
+    }
+    /* Check if we don't need to transmit the frame (DTX) */
+    if (tx == 0) {
+	output->buf = NULL;
+	output->size = 0;
+	output->timestamp.u64 = input->timestamp.u64;
+	output->type = PJMEDIA_FRAME_TYPE_NONE;
+	return PJ_SUCCESS;
+    }
+    output->size = tx;
+    output->type = PJMEDIA_FRAME_TYPE_AUDIO;
+    output->timestamp = input->timestamp;
+
+    return PJ_SUCCESS;
+
+on_return:
+    output->size = 0;
+    output->buf = NULL;
+    output->type = PJMEDIA_FRAME_TYPE_NONE;
+    output->timestamp.u64 = input->timestamp.u64;
+    return PJ_SUCCESS;
+}
+
+/*
+ * Decode frame.
+ */
+static pj_status_t and_media_codec_decode(pjmedia_codec *codec,
+					  const struct pjmedia_frame *input,
+					  unsigned output_buf_len,
+					  struct pjmedia_frame *output)
+{
+    and_media_private_t *codec_data = (and_media_private_t*) codec->codec_data;
+    struct and_media_codec *and_media_data =
+					&and_media_codec[codec_data->codec_idx];
+    unsigned samples_per_frame;
+    unsigned i;
+
+    pj_uint8_t pt;
+    pj_ssize_t buf_idx = -1;
+    pj_uint8_t *input_buf;
+    pj_size_t input_size;
+    pj_size_t output_size;
+    media_status_t am_status;
+    AMediaCodecBufferInfo buf_info;
+    pj_uint8_t *output_buf;
+    pjmedia_frame input_;
+
+    pj_bzero(&input_, sizeof(pjmedia_frame));
+    pt = and_media_data->pt;
+    samples_per_frame = and_media_data->samples_per_frame;
+
+    PJ_ASSERT_RETURN(output_buf_len >= samples_per_frame << 1,
+		     PJMEDIA_CODEC_EPCMTOOSHORT);
+
+    if (input->type != PJMEDIA_FRAME_TYPE_AUDIO)
+    {
+	goto on_return;
+    }
+
+    buf_idx = AMediaCodec_dequeueInputBuffer(codec_data->dec,
+					     CODEC_DEQUEUE_TIMEOUT);
+
+    if (buf_idx < 0) {
+	PJ_LOG(4,(THIS_FILE, "Decoder dequeueInputBuffer failed return %d",
+		  buf_idx));
+	goto on_return;
+    }
+
+    input_buf = AMediaCodec_getInputBuffer(codec_data->dec,
+					   buf_idx,
+					   &input_size);
+    if (input_buf == 0) {
+	PJ_LOG(4,(THIS_FILE, "Decoder getInputBuffer failed "
+		  "return input_buf=%d, size=%d", input_buf, input_size));
+	goto on_return;
+    }
+
+    if (and_media_data->predecode) {
+	input_.buf = input_buf;
+	and_media_data->predecode(codec_data, input, &input_);
+    } else {
+	input_.size = input->size;
+	pj_memcpy(input_buf, input->buf, input->size);
+    }
+
+    am_status = AMediaCodec_queueInputBuffer(codec_data->dec,
+					     buf_idx,
+					     0,
+					     input_.size,
+					     input->timestamp.u32.lo,
+					     0);
+    if (am_status != AMEDIA_OK) {
+	PJ_LOG(4,(THIS_FILE, "Decoder queueInputBuffer failed return %d",
+		  am_status));
+	goto on_return;
+    }
+
+    for (i = 0; i < CODEC_WAIT_RETRY; ++i) {
+	buf_idx = AMediaCodec_dequeueOutputBuffer(codec_data->dec,
+						  &buf_info,
+						  CODEC_DEQUEUE_TIMEOUT);
+	if (buf_idx == -1) {
+	    /* Timeout, wait until output buffer is availble. */
+	    PJ_LOG(5, (THIS_FILE, "Decoder dequeueOutputBuffer timeout[%d]",
+		       i+1));
+	    pj_thread_sleep(CODEC_THREAD_WAIT);
+	} else {
+	    break;
+	}
+    }
+    if (buf_idx < 0) {
+	PJ_LOG(5, (THIS_FILE, "Decoder dequeueOutputBuffer failed [%d]",
+		   buf_idx));
+	goto on_return;
+    }
+
+    output_buf = AMediaCodec_getOutputBuffer(codec_data->dec,
+					     buf_idx,
+					     &output_size);
+    if (output_buf == NULL) {
+	am_status = AMediaCodec_releaseOutputBuffer(codec_data->dec,
+					buf_idx,
+					0);
+	if (am_status != AMEDIA_OK) {
+	    PJ_LOG(4,(THIS_FILE, "Decoder releaseOutputBuffer failed %d",
+		      am_status));
+	}
+	PJ_LOG(4,(THIS_FILE, "Decoder getOutputBuffer failed"));
+	goto on_return;
+    }
+    pj_memcpy(output->buf, output_buf, buf_info.size);
+    output->type = PJMEDIA_FRAME_TYPE_AUDIO;
+    output->size = buf_info.size;
+    output->timestamp.u64 = input->timestamp.u64;
+    am_status = AMediaCodec_releaseOutputBuffer(codec_data->dec,
+						buf_idx,
+						0);
+
+    /* Invoke external PLC if codec has no internal PLC */
+    if (codec_data->plc && codec_data->plc_enabled)
+	pjmedia_plc_save(codec_data->plc, (pj_int16_t*)output->buf);
+
+    return PJ_SUCCESS;
+
+on_return:
+    pjmedia_zero_samples((pj_int16_t*)output->buf, samples_per_frame);
+    output->size = samples_per_frame << 1;
+    output->timestamp.u64 = input->timestamp.u64;
+    output->type = PJMEDIA_FRAME_TYPE_AUDIO;
+    return PJ_SUCCESS;
+}
+
+/* 
+ * Recover lost frame.
+ */
+static pj_status_t  and_media_codec_recover(pjmedia_codec *codec,
+					    unsigned output_buf_len,
+					    struct pjmedia_frame *output)
+{
+    and_media_private_t *codec_data = (and_media_private_t*) codec->codec_data;
+    struct and_media_codec *and_media_data =
+					&and_media_codec[codec_data->codec_idx];
+    unsigned samples_per_frame;
+    pj_bool_t generate_plc = (codec_data->plc_enabled && codec_data->plc);
+
+    PJ_UNUSED_ARG(output_buf_len);
+
+    samples_per_frame = and_media_data->samples_per_frame;
+    output->type = PJMEDIA_FRAME_TYPE_AUDIO;
+    output->size = samples_per_frame << 1;
+
+    if (generate_plc)
+	pjmedia_plc_generate(codec_data->plc, (pj_int16_t*)output->buf);
+    else
+	pjmedia_zero_samples((pj_int16_t*)output->buf, samples_per_frame);
+
+    return PJ_SUCCESS;
+}
+
+
+#endif	/* PJMEDIA_HAS_ANDROID_MEDIACODEC */
+

--- a/pjmedia/src/pjmedia-codec/and_vid_mediacodec.cpp
+++ b/pjmedia/src/pjmedia-codec/and_vid_mediacodec.cpp
@@ -1,0 +1,1933 @@
+/*
+ * Copyright (C)2020 Teluu Inc. (http://www.teluu.com)
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
+#include <pjmedia-codec/and_vid_mediacodec.h>
+#include <pjmedia-codec/h264_packetizer.h>
+#include <pjmedia-codec/vpx_packetizer.h>
+#include <pjmedia/vid_codec_util.h>
+#include <pjmedia/errno.h>
+#include <pj/log.h>
+
+#if defined(PJMEDIA_HAS_ANDROID_MEDIACODEC) && \
+            PJMEDIA_HAS_ANDROID_MEDIACODEC != 0 && \
+    defined(PJMEDIA_HAS_VIDEO) && (PJMEDIA_HAS_VIDEO != 0)
+
+/* Android AMediaCodec: */
+#include "media/NdkMediaCodec.h"
+
+/*
+ * Constants
+ */
+#define THIS_FILE		    "and_vid_mediacodec.cpp"
+#define AND_MEDIA_KEY_COLOR_FMT     "color-format"
+#define AND_MEDIA_KEY_WIDTH         "width"
+#define AND_MEDIA_KEY_HEIGHT        "height"
+#define AND_MEDIA_KEY_BIT_RATE      "bitrate"
+#define AND_MEDIA_KEY_PROFILE       "profile"
+#define AND_MEDIA_KEY_FRAME_RATE    "frame-rate"
+#define AND_MEDIA_KEY_IFR_INTTERVAL "i-frame-interval"
+#define AND_MEDIA_KEY_MIME          "mime"
+#define AND_MEDIA_KEY_REQUEST_SYNCF "request-sync"
+#define AND_MEDIA_KEY_CSD0	    "csd-0"
+#define AND_MEDIA_KEY_CSD1	    "csd-1"
+#define AND_MEDIA_KEY_MAX_INPUT_SZ  "max-input-size"
+#define AND_MEDIA_KEY_ENCODER	    "encoder"
+#define AND_MEDIA_KEY_PRIORITY	    "priority"
+#define AND_MEDIA_KEY_STRIDE	    "stride"
+#define AND_MEDIA_I420_PLANAR_FMT   0x13
+#define AND_MEDIA_QUEUE_TIMEOUT     2000*100
+
+#define DEFAULT_WIDTH		352
+#define DEFAULT_HEIGHT		288
+
+#define DEFAULT_FPS		15
+#define DEFAULT_AVG_BITRATE	256000
+#define DEFAULT_MAX_BITRATE	256000
+
+#define SPS_PPS_BUF_SIZE	64
+
+#define MAX_RX_WIDTH		1200
+#define MAX_RX_HEIGHT		800
+
+/* Maximum duration from one key frame to the next (in seconds). */
+#define KEYFRAME_INTERVAL	1
+
+#define CODEC_WAIT_RETRY 	10
+#define CODEC_THREAD_WAIT 	10
+/* Timeout until the buffer is ready in ms. */
+#define CODEC_DEQUEUE_TIMEOUT 	20
+
+#define AND_MED_H264_PT 	PJMEDIA_RTP_PT_H264_RSV2
+#define AND_MED_VP8_PT 		PJMEDIA_RTP_PT_VP8_RSV1
+#define AND_MED_VP9_PT 		PJMEDIA_RTP_PT_VP9_RSV1
+
+/*
+ * Factory operations.
+ */
+static pj_status_t and_media_test_alloc(pjmedia_vid_codec_factory *factory,
+                                    const pjmedia_vid_codec_info *info );
+static pj_status_t and_media_default_attr(pjmedia_vid_codec_factory *factory,
+                                      const pjmedia_vid_codec_info *info,
+                                      pjmedia_vid_codec_param *attr );
+static pj_status_t and_media_enum_info(pjmedia_vid_codec_factory *factory,
+                                   unsigned *count,
+                                   pjmedia_vid_codec_info codecs[]);
+static pj_status_t and_media_alloc_codec(pjmedia_vid_codec_factory *factory,
+                                     const pjmedia_vid_codec_info *info,
+                                     pjmedia_vid_codec **p_codec);
+static pj_status_t and_media_dealloc_codec(pjmedia_vid_codec_factory *factory,
+                                       pjmedia_vid_codec *codec );
+
+
+/*
+ * Codec operations
+ */
+static pj_status_t and_media_codec_init(pjmedia_vid_codec *codec,
+                                    pj_pool_t *pool );
+static pj_status_t and_media_codec_open(pjmedia_vid_codec *codec,
+                                    pjmedia_vid_codec_param *param );
+static pj_status_t and_media_codec_close(pjmedia_vid_codec *codec);
+static pj_status_t and_media_codec_modify(pjmedia_vid_codec *codec,
+                                      const pjmedia_vid_codec_param *param);
+static pj_status_t and_media_codec_get_param(pjmedia_vid_codec *codec,
+                                         pjmedia_vid_codec_param *param);
+static pj_status_t and_media_codec_encode_begin(pjmedia_vid_codec *codec,
+                                            const pjmedia_vid_encode_opt *opt,
+                                            const pjmedia_frame *input,
+                                            unsigned out_size,
+                                            pjmedia_frame *output,
+                                            pj_bool_t *has_more);
+static pj_status_t and_media_codec_encode_more(pjmedia_vid_codec *codec,
+                                           unsigned out_size,
+                                           pjmedia_frame *output,
+                                           pj_bool_t *has_more);
+static pj_status_t and_media_codec_decode(pjmedia_vid_codec *codec,
+                                      pj_size_t count,
+                                      pjmedia_frame packets[],
+                                      unsigned out_size,
+                                      pjmedia_frame *output);
+
+/* Definition for Android AMediaCodec operations. */
+static pjmedia_vid_codec_op and_media_codec_op =
+{
+    &and_media_codec_init,
+    &and_media_codec_open,
+    &and_media_codec_close,
+    &and_media_codec_modify,
+    &and_media_codec_get_param,
+    &and_media_codec_encode_begin,
+    &and_media_codec_encode_more,
+    &and_media_codec_decode,
+    NULL
+};
+
+/* Definition for Android AMediaCodec factory operations. */
+static pjmedia_vid_codec_factory_op and_media_factory_op =
+{
+    &and_media_test_alloc,
+    &and_media_default_attr,
+    &and_media_enum_info,
+    &and_media_alloc_codec,
+    &and_media_dealloc_codec
+};
+
+static struct and_media_factory
+{
+    pjmedia_vid_codec_factory    base;
+    pjmedia_vid_codec_mgr	*mgr;
+    pj_pool_factory             *pf;
+    pj_pool_t		        *pool;
+} and_media_factory;
+
+enum and_media_frm_type {
+    AND_MEDIA_FRM_TYPE_DEFAULT = 0,
+    AND_MEDIA_FRM_TYPE_KEYFRAME = 1,
+    AND_MEDIA_FRM_TYPE_CONFIG = 2
+};
+
+typedef struct h264_codec_data {
+    pjmedia_h264_packetizer	*pktz;
+
+    pj_uint8_t			 enc_sps_pps_buf[SPS_PPS_BUF_SIZE];
+    unsigned			 enc_sps_pps_len;
+    pj_bool_t			 enc_sps_pps_ex;
+
+    pj_uint8_t			*dec_sps_buf;
+    unsigned			 dec_sps_len;
+    pj_uint8_t			*dec_pps_buf;
+    unsigned			 dec_pps_len;
+} h264_codec_data;
+
+typedef struct vpx_codec_data {
+    pjmedia_vpx_packetizer	*pktz;
+} vpx_codec_data;
+
+typedef struct and_media_codec_data
+{
+    pj_pool_t			*pool;
+    pj_uint8_t                   codec_idx;
+    pjmedia_vid_codec_param	*prm;
+    pj_bool_t			 whole;
+    void                        *ex_data;
+
+    /* Encoder state */
+    AMediaCodec                 *enc;
+    unsigned		 	 enc_input_size;
+    pj_uint8_t			*enc_frame_whole;
+    unsigned			 enc_frame_size;
+    unsigned			 enc_processed;
+    AMediaCodecBufferInfo        enc_buf_info;
+    int				 enc_output_buf_idx;
+
+    /* Decoder state */
+    AMediaCodec                 *dec;
+    pj_uint8_t			*dec_buf;
+    pj_uint8_t			*dec_input_buf;
+    unsigned			 dec_input_buf_len;
+    pj_size_t			 dec_input_buf_max_size;
+    pj_ssize_t			 dec_input_buf_idx;
+    unsigned			 dec_has_output_frame;
+    unsigned			 dec_stride_len;
+    unsigned			 dec_buf_size;
+    AMediaCodecBufferInfo        dec_buf_info;
+} and_media_codec_data;
+
+/* Custom callbacks. */
+
+/* This callback is useful when specific method is needed when opening
+ * the codec (e.g: applying fmtp or setting up the packetizer)
+ */
+typedef pj_status_t (*open_cb)(and_media_codec_data *and_media_data);
+
+/* This callback is useful for handling configure frame produced by encoder.
+ * Output frame might want to be stored the configuration frame and append it
+ * to a keyframe for sending later (e.g: on H264 codec). The default behavior
+ * is to send the configuration frame regardless.
+ */
+typedef pj_status_t (*process_encode_cb)(and_media_codec_data *and_media_data);
+
+/* This callback is to process more encoded packets/payloads from the codec.*/
+typedef pj_status_t(*encode_more_cb)(and_media_codec_data *and_media_data,
+                                     unsigned out_size,
+                                     pjmedia_frame *output,
+                                     pj_bool_t *has_more);
+
+/* This callback is to decode packets. */
+typedef pj_status_t(*decode_cb)(pjmedia_vid_codec *codec,
+                                pj_size_t count,
+                                pjmedia_frame packets[],
+                                unsigned out_size,
+                                pjmedia_frame *output);
+
+
+/* Custom callback implementation. */
+#if PJMEDIA_HAS_AND_MEDIA_H264
+static pj_status_t open_h264(and_media_codec_data *and_media_data);
+static pj_status_t process_encode_h264(and_media_codec_data *and_media_data);
+static pj_status_t encode_more_h264(and_media_codec_data *and_media_data,
+                                    unsigned out_size,
+                                    pjmedia_frame *output,
+                                    pj_bool_t *has_more);
+static pj_status_t decode_h264(pjmedia_vid_codec *codec,
+                               pj_size_t count,
+                               pjmedia_frame packets[],
+                               unsigned out_size,
+                               pjmedia_frame *output);
+#endif
+
+#if PJMEDIA_HAS_AND_MEDIA_VP8 || PJMEDIA_HAS_AND_MEDIA_VP9
+static pj_status_t open_vpx(and_media_codec_data *and_media_data);
+static pj_status_t encode_more_vpx(and_media_codec_data *and_media_data,
+                                   unsigned out_size,
+                                   pjmedia_frame *output,
+                                   pj_bool_t *has_more);
+static pj_status_t decode_vpx(pjmedia_vid_codec *codec,
+                              pj_size_t count,
+                              pjmedia_frame packets[],
+                              unsigned out_size,
+                              pjmedia_frame *output);
+#endif
+
+
+#if PJMEDIA_HAS_AND_MEDIA_H264
+static pj_str_t H264_sw_encoder[] = {{(char *)"OMX.google.h264.encoder\0",
+				      23}};
+static pj_str_t H264_hw_encoder[] =
+				  {{(char *)"OMX.qcom.video.encoder.avc\0", 26},
+			          {(char *)"OMX.Exynos.avc.Encoder\0", 22}};
+static pj_str_t H264_sw_decoder[] = {{(char *)"OMX.google.h264.decoder\0",
+				      23}};
+static pj_str_t H264_hw_decoder[] =
+				  {{(char *)"OMX.qcom.video.decoder.avc\0", 26},
+			          {(char *)"OMX.Exynos.avc.dec\0", 18}};
+#endif
+
+#if PJMEDIA_HAS_AND_MEDIA_VP8
+static pj_str_t VP8_sw_encoder[] = {{(char *)"OMX.google.vp8.encoder\0", 23}};
+static pj_str_t VP8_hw_encoder[] =
+				 {{(char *)"OMX.qcom.video.encoder.vp8\0", 26},
+			         {(char *)"OMX.Exynos.vp8.Encoder\0", 22}};
+static pj_str_t VP8_sw_decoder[] = {{(char *)"OMX.google.vp8.decoder\0", 23}};
+static pj_str_t VP8_hw_decoder[] =
+				 {{(char *)"OMX.qcom.video.decoder.vp8\0", 26},
+			         {(char *)"OMX.Exynos.vp8.dec\0", 18}};
+#endif
+
+#if PJMEDIA_HAS_AND_MEDIA_VP9
+static pj_str_t VP9_sw_encoder[] = {{(char *)"OMX.google.vp9.encoder\0", 23}};
+static pj_str_t VP9_hw_encoder[] =
+				 {{(char *)"OMX.qcom.video.encoder.vp9\0", 26},
+			         {(char *)"OMX.Exynos.vp9.Encoder\0", 22}};
+static pj_str_t VP9_sw_decoder[] = {{(char *)"OMX.google.vp9.decoder\0", 23}};
+static pj_str_t VP9_hw_decoder[] =
+				 {{(char *)"OMX.qcom.video.decoder.vp9\0", 26},
+			         {(char *)"OMX.Exynos.vp9.dec\0", 18}};
+#endif
+
+static struct and_media_codec {
+    int		       enabled;		  /* Is this codec enabled?	     */
+    const char	      *name;		  /* Codec name.		     */
+    const char        *description;       /* Codec description.              */
+    const char        *mime_type;         /* Mime type.                      */
+    pj_str_t          *encoder_name;      /* Encoder name.                   */
+    pj_str_t          *decoder_name;      /* Decoder name.                   */
+    pj_uint8_t	       pt;		  /* Payload type.		     */
+    pjmedia_format_id  fmt_id;		  /* Format id.   		     */
+    pj_uint8_t         keyframe_interval; /* Keyframe interval.              */
+
+    open_cb            open_codec;
+    process_encode_cb  process_encode;
+    encode_more_cb     encode_more;
+    decode_cb          decode;
+
+    pjmedia_codec_fmtp dec_fmtp;	  /* Decoder's fmtp params.	     */
+}
+and_media_codec[] = {
+#if PJMEDIA_HAS_AND_MEDIA_H264
+    {0, "H264",	"Android MediaCodec H264 codec", "video/avc",
+        NULL, NULL,
+        AND_MED_H264_PT, PJMEDIA_FORMAT_H264, KEYFRAME_INTERVAL,
+        &open_h264, &process_encode_h264, &encode_more_h264, &decode_h264,
+        {2, {{{(char *)"profile-level-id", 16}, {(char *)"42e01e", 6}},
+             {{(char *)" packetization-mode", 19}, {(char *)"1", 1}}}
+        }
+    },
+#endif
+#if PJMEDIA_HAS_AND_MEDIA_VP8
+    {0, "VP8",	"Android MediaCodec VP8 codec", "video/x-vnd.on2.vp8",
+        NULL, NULL,
+        AND_MED_VP8_PT, PJMEDIA_FORMAT_VP8, KEYFRAME_INTERVAL,
+        &open_vpx, NULL, &encode_more_vpx, &decode_vpx,
+        {2, {{{(char *)"max-fr", 6}, {(char *)"30", 2}},
+             {{(char *)" max-fs", 7}, {(char *)"580", 3}}}
+        }
+    },
+#endif
+#if PJMEDIA_HAS_AND_MEDIA_VP9
+    {0, "VP9",	"Android MediaCodec VP9 codec", "video/x-vnd.on2.vp9",
+	NULL, NULL,
+	AND_MED_VP9_PT, PJMEDIA_FORMAT_VP9, KEYFRAME_INTERVAL,
+        &open_vpx, NULL, &encode_more_vpx, &decode_vpx,
+        {2, {{{(char *)"max-fr", 6}, {(char *)"30", 2}},
+             {{(char *)" max-fs", 7}, {(char *)"580", 3}}}
+        }
+    }
+#endif
+};
+
+static pj_status_t configure_encoder(and_media_codec_data *and_media_data)
+{
+    media_status_t am_status;
+    AMediaFormat *vid_fmt;
+    pjmedia_vid_codec_param *param = and_media_data->prm;
+
+    vid_fmt = AMediaFormat_new();
+    if (!vid_fmt) {
+	PJ_LOG(4, (THIS_FILE, "Encoder failed creating media format"));
+        return PJ_ENOMEM;
+    }
+
+    AMediaFormat_setString(vid_fmt, AND_MEDIA_KEY_MIME,
+                          and_media_codec[and_media_data->codec_idx].mime_type);
+    AMediaFormat_setInt32(vid_fmt, AND_MEDIA_KEY_COLOR_FMT,
+			  AND_MEDIA_I420_PLANAR_FMT);
+    AMediaFormat_setInt32(vid_fmt, AND_MEDIA_KEY_HEIGHT,
+			  param->enc_fmt.det.vid.size.h);
+    AMediaFormat_setInt32(vid_fmt, AND_MEDIA_KEY_WIDTH,
+                          param->enc_fmt.det.vid.size.w);
+    AMediaFormat_setInt32(vid_fmt, AND_MEDIA_KEY_BIT_RATE,
+                          param->enc_fmt.det.vid.avg_bps);
+    //AMediaFormat_setInt32(vid_fmt, AND_MEDIA_KEY_PROFILE, 1);
+    AMediaFormat_setInt32(vid_fmt, AND_MEDIA_KEY_IFR_INTTERVAL,
+			  KEYFRAME_INTERVAL);
+    AMediaFormat_setInt32(vid_fmt, AND_MEDIA_KEY_FRAME_RATE,
+                          (param->enc_fmt.det.vid.fps.num /
+                           param->enc_fmt.det.vid.fps.denum));
+    AMediaFormat_setInt32(vid_fmt, AND_MEDIA_KEY_PRIORITY, 0);
+
+    /* Configure and start encoder. */
+    am_status = AMediaCodec_configure(and_media_data->enc, vid_fmt, NULL, NULL,
+                                      AMEDIACODEC_CONFIGURE_FLAG_ENCODE);
+    AMediaFormat_delete(vid_fmt);
+    if (am_status != AMEDIA_OK) {
+        PJ_LOG(4, (THIS_FILE, "Encoder configure failed, status=%d",
+        	   am_status));
+        return PJMEDIA_CODEC_EFAILED;
+    }
+    am_status = AMediaCodec_start(and_media_data->enc);
+    if (am_status != AMEDIA_OK) {
+	PJ_LOG(4, (THIS_FILE, "Encoder start failed, status=%d",
+		am_status));
+	return PJMEDIA_CODEC_EFAILED;
+    }
+    return PJ_SUCCESS;
+}
+
+static pj_status_t configure_decoder(and_media_codec_data *and_media_data) {
+    media_status_t am_status;
+    AMediaFormat *vid_fmt;
+
+    vid_fmt = AMediaFormat_new();
+    if (!vid_fmt) {
+	PJ_LOG(4, (THIS_FILE, "Decoder failed creating media format"));
+        return PJ_ENOMEM;
+    }
+    AMediaFormat_setString(vid_fmt, AND_MEDIA_KEY_MIME,
+                          and_media_codec[and_media_data->codec_idx].mime_type);
+    AMediaFormat_setInt32(vid_fmt, AND_MEDIA_KEY_COLOR_FMT,
+			  AND_MEDIA_I420_PLANAR_FMT);
+    AMediaFormat_setInt32(vid_fmt, AND_MEDIA_KEY_HEIGHT,
+	                  and_media_data->prm->dec_fmt.det.vid.size.h);
+    AMediaFormat_setInt32(vid_fmt, AND_MEDIA_KEY_WIDTH,
+	                  and_media_data->prm->dec_fmt.det.vid.size.w);
+    AMediaFormat_setInt32(vid_fmt, AND_MEDIA_KEY_MAX_INPUT_SZ, 0);
+    AMediaFormat_setInt32(vid_fmt, AND_MEDIA_KEY_ENCODER, 0);
+    AMediaFormat_setInt32(vid_fmt, AND_MEDIA_KEY_PRIORITY, 0);
+
+    if (and_media_data->prm->dec_fmt.id == PJMEDIA_FORMAT_H264) {
+	h264_codec_data *h264_data = (h264_codec_data *)and_media_data->ex_data;
+
+	if (h264_data->dec_sps_len) {
+	    AMediaFormat_setBuffer(vid_fmt, AND_MEDIA_KEY_CSD0,
+				   h264_data->dec_sps_buf,
+				   h264_data->dec_sps_len);
+	}
+	if (h264_data->dec_pps_len) {
+	    AMediaFormat_setBuffer(vid_fmt, AND_MEDIA_KEY_CSD1,
+				   h264_data->dec_pps_buf,
+				   h264_data->dec_pps_len);
+	}
+    }
+    am_status = AMediaCodec_configure(and_media_data->dec, vid_fmt, NULL,
+				      NULL, 0);
+
+    AMediaFormat_delete(vid_fmt);
+    if (am_status != AMEDIA_OK) {
+        PJ_LOG(4, (THIS_FILE, "Decoder configure failed, status=%d, fmt_id=%d",
+        	   am_status, and_media_data->prm->dec_fmt.id));
+        return PJMEDIA_CODEC_EFAILED;
+    }
+
+    am_status = AMediaCodec_start(and_media_data->dec);
+    if (am_status != AMEDIA_OK) {
+	PJ_LOG(4, (THIS_FILE, "Decoder start failed, status=%d",
+		   am_status));
+	return PJMEDIA_CODEC_EFAILED;
+    }
+    return PJ_SUCCESS;
+}
+
+PJ_DEF(pj_status_t) pjmedia_codec_and_media_vid_init(
+						pjmedia_vid_codec_mgr *mgr,
+                                                pj_pool_factory *pf)
+{
+    const pj_str_t h264_name = { (char*)"H264", 4};
+    pj_status_t status;
+
+    if (and_media_factory.pool != NULL) {
+	/* Already initialized. */
+	return PJ_SUCCESS;
+    }
+
+    if (!mgr) mgr = pjmedia_vid_codec_mgr_instance();
+    PJ_ASSERT_RETURN(mgr, PJ_EINVAL);
+
+    /* Create Android AMediaCodec codec factory. */
+    and_media_factory.base.op = &and_media_factory_op;
+    and_media_factory.base.factory_data = NULL;
+    and_media_factory.mgr = mgr;
+    and_media_factory.pf = pf;
+    and_media_factory.pool = pj_pool_create(pf, "and_media_vid_factory",
+					    256, 256, NULL);
+    if (!and_media_factory.pool)
+	return PJ_ENOMEM;
+
+#if PJMEDIA_HAS_AND_MEDIA_H264
+    /* Registering format match for SDP negotiation */
+    status = pjmedia_sdp_neg_register_fmt_match_cb(
+					&h264_name,
+					&pjmedia_vid_codec_h264_match_sdp);
+    if (status != PJ_SUCCESS)
+	goto on_error;
+#endif
+
+    /* Register codec factory to codec manager. */
+    status = pjmedia_vid_codec_mgr_register_factory(mgr,
+						    &and_media_factory.base);
+    if (status != PJ_SUCCESS)
+	goto on_error;
+
+    PJ_LOG(4,(THIS_FILE, "Android AMediaCodec initialized"));
+
+    /* Done. */
+    return PJ_SUCCESS;
+
+on_error:
+    pj_pool_release(and_media_factory.pool);
+    and_media_factory.pool = NULL;
+    return status;
+}
+
+/*
+ * Unregister Android AMediaCodec factory from pjmedia endpoint.
+ */
+PJ_DEF(pj_status_t) pjmedia_codec_and_media_vid_deinit(void)
+{
+    pj_status_t status = PJ_SUCCESS;
+
+    if (and_media_factory.pool == NULL) {
+	/* Already deinitialized */
+	return PJ_SUCCESS;
+    }
+
+    /* Unregister Android AMediaCodec factory. */
+    status = pjmedia_vid_codec_mgr_unregister_factory(and_media_factory.mgr,
+						      &and_media_factory.base);
+
+    /* Destroy pool. */
+    pj_pool_release(and_media_factory.pool);
+    and_media_factory.pool = NULL;
+
+    return status;
+}
+
+static pj_status_t and_media_test_alloc(pjmedia_vid_codec_factory *factory,
+                                    const pjmedia_vid_codec_info *info )
+{
+    unsigned i;
+
+    PJ_ASSERT_RETURN(factory == &and_media_factory.base, PJ_EINVAL);
+
+    for (i = 0; i < PJ_ARRAY_SIZE(and_media_codec); ++i) {
+        if (and_media_codec[i].enabled && info->pt == and_media_codec[i].pt &&
+            (info->fmt_id == and_media_codec[i].fmt_id))
+        {
+            return PJ_SUCCESS;
+        }
+    }
+
+    return PJMEDIA_CODEC_EUNSUP;
+}
+
+static pj_status_t and_media_default_attr(pjmedia_vid_codec_factory *factory,
+                                      const pjmedia_vid_codec_info *info,
+                                      pjmedia_vid_codec_param *attr )
+{
+    unsigned i;
+
+    PJ_ASSERT_RETURN(factory == &and_media_factory.base, PJ_EINVAL);
+    PJ_ASSERT_RETURN(info && attr, PJ_EINVAL);
+
+    for (i = 0; i < PJ_ARRAY_SIZE(and_media_codec); ++i) {
+        if (and_media_codec[i].enabled && info->pt != 0 &&
+            (info->fmt_id == and_media_codec[i].fmt_id))
+        {
+            break;
+        }
+    }
+
+    if (i == PJ_ARRAY_SIZE(and_media_codec))
+        return PJ_EINVAL;
+
+    pj_bzero(attr, sizeof(pjmedia_vid_codec_param));
+
+    attr->dir = PJMEDIA_DIR_ENCODING_DECODING;
+    attr->packing = PJMEDIA_VID_PACKING_PACKETS;
+
+    /* Encoded format */
+    pjmedia_format_init_video(&attr->enc_fmt, info->fmt_id,
+                              DEFAULT_WIDTH, DEFAULT_HEIGHT, DEFAULT_FPS, 1);
+
+    /* Decoded format */
+    pjmedia_format_init_video(&attr->dec_fmt, PJMEDIA_FORMAT_I420,
+                              DEFAULT_WIDTH, DEFAULT_HEIGHT, DEFAULT_FPS, 1);
+
+    attr->dec_fmtp = and_media_codec[i].dec_fmtp;
+
+    /* Bitrate */
+    attr->enc_fmt.det.vid.avg_bps = DEFAULT_AVG_BITRATE;
+    attr->enc_fmt.det.vid.max_bps = DEFAULT_MAX_BITRATE;
+
+    /* Encoding MTU */
+    attr->enc_mtu = PJMEDIA_MAX_VID_PAYLOAD_SIZE;
+
+    return PJ_SUCCESS;
+}
+
+static pj_bool_t codec_exists(const pj_str_t *codec_name)
+{
+    AMediaCodec *codec;
+    char *codec_txt;
+
+    codec_txt = codec_name->ptr;
+
+    codec = AMediaCodec_createCodecByName(codec_txt);
+    if (!codec) {
+	PJ_LOG(4, (THIS_FILE, "Failed creating codec : %.*s", codec_name->slen,
+		   codec_name->ptr));
+	return PJ_FALSE;
+    }
+    AMediaCodec_delete(codec);
+
+    return PJ_TRUE;
+}
+
+void add_codec(struct and_media_codec *codec,
+	       unsigned *count, pjmedia_vid_codec_info *info)
+{
+    info[*count].fmt_id = codec->fmt_id;
+    info[*count].pt = codec->pt;
+    info[*count].encoding_name = pj_str((char *)codec->name);
+    info[*count].encoding_desc = pj_str((char *)codec->description);
+
+    info[*count].clock_rate = 90000;
+    info[*count].dir = PJMEDIA_DIR_ENCODING_DECODING;
+    info[*count].dec_fmt_id_cnt = 1;
+    info[*count].dec_fmt_id[0] = PJMEDIA_FORMAT_I420;
+    info[*count].packings = PJMEDIA_VID_PACKING_PACKETS;
+    info[*count].fps_cnt = 3;
+    info[*count].fps[0].num = 15;
+    info[*count].fps[0].denum = 1;
+    info[*count].fps[1].num = 25;
+    info[*count].fps[1].denum = 1;
+    info[*count].fps[2].num = 30;
+    info[*count].fps[2].denum = 1;
+    ++*count;
+}
+
+static void get_codec_name(pj_bool_t is_enc,
+	                   pj_bool_t prio,
+			   pjmedia_format_id fmt_id,
+			   pj_str_t **codec_name,
+			   unsigned *codec_num)
+{
+    pj_bool_t use_sw_enc = PJMEDIA_AND_MEDIA_PRIO_SW_VID_ENC;
+    pj_bool_t use_sw_dec = PJMEDIA_AND_MEDIA_PRIO_SW_VID_DEC;
+
+    *codec_num = 0;
+
+    switch (fmt_id) {
+
+#if PJMEDIA_HAS_AND_MEDIA_H264
+    case PJMEDIA_FORMAT_H264:
+	if (is_enc) {
+	    if ((prio && use_sw_enc) || (!prio && !use_sw_enc)) {
+		*codec_name = &H264_sw_encoder[0];
+		*codec_num = PJ_ARRAY_SIZE(H264_sw_encoder);
+	    } else {
+		*codec_name = &H264_hw_encoder[0];
+		*codec_num = PJ_ARRAY_SIZE(H264_hw_encoder);
+	    }
+	} else {
+	    if ((prio && use_sw_dec) || (!prio && !use_sw_dec)) {
+		*codec_name = &H264_sw_decoder[0];
+		*codec_num = PJ_ARRAY_SIZE(H264_sw_decoder);
+	    } else {
+		*codec_name = &H264_hw_decoder[0];
+		*codec_num = PJ_ARRAY_SIZE(H264_hw_decoder);
+	    }
+	}
+	break;
+#endif
+#if PJMEDIA_HAS_AND_MEDIA_VP8
+    case PJMEDIA_FORMAT_VP8:
+	if (is_enc) {
+	    if ((prio && use_sw_enc) || (!prio && !use_sw_enc)) {
+		*codec_name = &VP8_sw_encoder[0];
+		*codec_num = PJ_ARRAY_SIZE(VP8_sw_encoder);
+	    } else {
+		*codec_name = &VP8_hw_encoder[0];
+		*codec_num = PJ_ARRAY_SIZE(VP8_hw_encoder);
+	    }
+	} else {
+	    if ((prio && use_sw_dec) || (!prio && !use_sw_dec)) {
+		*codec_name = &VP8_sw_decoder[0];
+		*codec_num = PJ_ARRAY_SIZE(VP8_sw_decoder);
+	    } else {
+		*codec_name = &VP8_hw_decoder[0];
+		*codec_num = PJ_ARRAY_SIZE(VP8_hw_decoder);
+	    }
+	}
+	break;
+#endif
+#if PJMEDIA_HAS_AND_MEDIA_VP9
+    case PJMEDIA_FORMAT_VP9:
+	if (is_enc) {
+	    if ((prio && use_sw_enc) || (!prio && !use_sw_enc)) {
+		*codec_name = &VP9_sw_encoder[0];
+		*codec_num = PJ_ARRAY_SIZE(VP9_sw_encoder);
+	    } else {
+		*codec_name = &VP9_hw_encoder[0];
+		*codec_num = PJ_ARRAY_SIZE(VP9_hw_encoder);
+	    }
+	} else {
+	    if ((prio && use_sw_dec) || (!prio && !use_sw_dec)) {
+		*codec_name = &VP9_sw_decoder[0];
+		*codec_num = PJ_ARRAY_SIZE(VP9_sw_decoder);
+	    } else {
+		*codec_name = &VP9_hw_decoder[0];
+		*codec_num = PJ_ARRAY_SIZE(VP9_hw_decoder);
+	    }
+	}
+	break;
+#endif
+    default:
+	break;
+    }
+}
+
+static pj_status_t and_media_enum_info(pjmedia_vid_codec_factory *factory,
+                                   unsigned *count,
+                                   pjmedia_vid_codec_info info[])
+{
+    unsigned i, max;
+
+    PJ_ASSERT_RETURN(info && *count > 0, PJ_EINVAL);
+    PJ_ASSERT_RETURN(factory == &and_media_factory.base, PJ_EINVAL);
+
+    max = *count;
+
+    for (i = 0, *count = 0; i < PJ_ARRAY_SIZE(and_media_codec) && *count < max;
+	 ++i)
+    {
+	unsigned enc_idx = 0;
+	unsigned dec_idx = 0;
+	pj_str_t *enc_name = NULL;
+	unsigned num_enc;
+	pj_str_t *dec_name = NULL;
+	unsigned num_dec;
+
+	get_codec_name(PJ_TRUE, PJ_TRUE, and_media_codec[i].fmt_id,
+		       &enc_name, &num_enc);
+
+	for (enc_idx = 0; enc_idx < num_enc ;++enc_idx, ++enc_name) {
+	    if (codec_exists(enc_name)) {
+		break;
+	    }
+	}
+	if (enc_idx == num_enc) {
+	    get_codec_name(PJ_TRUE, PJ_FALSE, and_media_codec[i].fmt_id,
+			   &enc_name, &num_enc);
+
+	    for (enc_idx = 0; enc_idx < num_enc ;++enc_idx, ++enc_name) {
+		if (codec_exists(enc_name)) {
+		    break;
+		}
+	    }
+	    if (enc_idx == num_enc)
+		continue;
+	}
+
+	get_codec_name(PJ_FALSE, PJ_TRUE, and_media_codec[i].fmt_id,
+		       &dec_name, &num_dec);
+	for (dec_idx = 0; dec_idx < num_dec ;++dec_idx, ++dec_name) {
+	    if (codec_exists(dec_name)) {
+		break;
+	    }
+	}
+	if (dec_idx == num_dec) {
+	    get_codec_name(PJ_FALSE, PJ_FALSE, and_media_codec[i].fmt_id,
+			   &dec_name, &num_dec);
+	    for (enc_idx = 0; enc_idx < num_enc ;++enc_idx, ++enc_name) {
+		if (codec_exists(enc_name)) {
+		    break;
+		}
+	    }
+	    if (dec_idx == num_dec)
+		continue;
+	}
+
+	and_media_codec[i].encoder_name = enc_name;
+	and_media_codec[i].decoder_name = dec_name;
+	PJ_LOG(4, (THIS_FILE, "Found encoder [%d]: %.*s and decoder: %.*s ",
+		   *count, enc_name->slen, enc_name->ptr, dec_name->slen,
+		   dec_name->ptr));
+	add_codec(&and_media_codec[*count], count, info);
+	and_media_codec[i].enabled = PJ_TRUE;
+    }
+
+    return PJ_SUCCESS;
+}
+
+static void create_codec(struct and_media_codec_data *and_media_data)
+{
+    char *enc_name;
+    char *dec_name;
+
+    if (!and_media_codec[and_media_data->codec_idx].encoder_name ||
+	!and_media_codec[and_media_data->codec_idx].decoder_name)
+    {
+	return;
+    }
+
+    enc_name = and_media_codec[and_media_data->codec_idx].encoder_name->ptr;
+    dec_name = and_media_codec[and_media_data->codec_idx].decoder_name->ptr;
+
+    if (!and_media_data->enc) {
+	and_media_data->enc = AMediaCodec_createCodecByName(enc_name);
+	if (!and_media_data->enc) {
+	    PJ_LOG(4, (THIS_FILE, "Failed creating encoder: %s", enc_name));
+	}
+    }
+
+    if (!and_media_data->dec) {
+	and_media_data->dec = AMediaCodec_createCodecByName(dec_name);
+	if (!and_media_data->dec) {
+	    PJ_LOG(4, (THIS_FILE, "Failed creating decoder: %s", dec_name));
+	}
+    }
+    PJ_LOG(4, (THIS_FILE, "Created encoder: %s, decoder: %s", enc_name,
+	       dec_name));
+}
+
+static pj_status_t and_media_alloc_codec(pjmedia_vid_codec_factory *factory,
+                                     const pjmedia_vid_codec_info *info,
+                                     pjmedia_vid_codec **p_codec)
+{
+    pj_pool_t *pool;
+    pjmedia_vid_codec *codec;
+    and_media_codec_data *and_media_data;
+    int i, idx;
+
+    PJ_ASSERT_RETURN(factory == &and_media_factory.base && info && p_codec,
+                     PJ_EINVAL);
+
+    idx = -1;
+    for (i = 0; i < PJ_ARRAY_SIZE(and_media_codec); ++i) {
+	if ((info->fmt_id == and_media_codec[i].fmt_id) &&
+            (and_media_codec[i].enabled))
+	{
+	    idx = i;
+	    break;
+	}
+    }
+    if (idx == -1) {
+	*p_codec = NULL;
+	return PJMEDIA_CODEC_EFAILED;
+    }
+
+    *p_codec = NULL;
+    pool = pj_pool_create(and_media_factory.pf, "anmedvid%p", 512, 512, NULL);
+    if (!pool)
+	return PJ_ENOMEM;
+
+    /* codec instance */
+    codec = PJ_POOL_ZALLOC_T(pool, pjmedia_vid_codec);
+    codec->factory = factory;
+    codec->op = &and_media_codec_op;
+
+    /* codec data */
+    and_media_data = PJ_POOL_ZALLOC_T(pool, and_media_codec_data);
+    and_media_data->pool = pool;
+    and_media_data->codec_idx = idx;
+    codec->codec_data = and_media_data;
+
+    create_codec(and_media_data);
+    if (!and_media_data->enc || !and_media_data->dec) {
+	goto on_error;
+    }
+
+    *p_codec = codec;
+    return PJ_SUCCESS;
+
+on_error:
+    and_media_dealloc_codec(factory, codec);
+    return PJMEDIA_CODEC_EFAILED;
+}
+
+static pj_status_t and_media_dealloc_codec(pjmedia_vid_codec_factory *factory,
+                                       pjmedia_vid_codec *codec )
+{
+    and_media_codec_data *and_media_data;
+
+    PJ_ASSERT_RETURN(codec, PJ_EINVAL);
+
+    PJ_UNUSED_ARG(factory);
+
+    and_media_data = (and_media_codec_data*) codec->codec_data;
+    if (and_media_data->enc) {
+        AMediaCodec_stop(and_media_data->enc);
+        AMediaCodec_delete(and_media_data->enc);
+        and_media_data->enc = NULL;
+    }
+
+    if (and_media_data->dec) {
+        AMediaCodec_stop(and_media_data->dec);
+        AMediaCodec_delete(and_media_data->dec);
+        and_media_data->dec = NULL;
+    }
+    pj_pool_release(and_media_data->pool);
+    return PJ_SUCCESS;
+}
+
+static pj_status_t and_media_codec_init(pjmedia_vid_codec *codec,
+                                    pj_pool_t *pool )
+{
+    PJ_ASSERT_RETURN(codec && pool, PJ_EINVAL);
+    PJ_UNUSED_ARG(codec);
+    PJ_UNUSED_ARG(pool);
+    return PJ_SUCCESS;
+}
+
+static pj_status_t and_media_codec_open(pjmedia_vid_codec *codec,
+                                    pjmedia_vid_codec_param *codec_param)
+{
+    and_media_codec_data *and_media_data;
+    pjmedia_vid_codec_param *param;
+    pj_status_t status = PJ_SUCCESS;
+
+    and_media_data = (and_media_codec_data*) codec->codec_data;
+    and_media_data->prm = pjmedia_vid_codec_param_clone( and_media_data->pool,
+                                                     codec_param);
+    param = and_media_data->prm;
+    if (and_media_codec[and_media_data->codec_idx].open_codec) {
+        status = and_media_codec[and_media_data->codec_idx].open_codec(
+        							and_media_data);
+        if (status != PJ_SUCCESS)
+            return status;
+    }
+    and_media_data->whole = (param->packing == PJMEDIA_VID_PACKING_WHOLE);
+    status = configure_encoder(and_media_data);
+    if (status != PJ_SUCCESS) {
+        return PJMEDIA_CODEC_EFAILED;
+    }
+    status = configure_decoder(and_media_data);
+    if (status != PJ_SUCCESS) {
+        return PJMEDIA_CODEC_EFAILED;
+    }
+    if (and_media_data->dec_buf_size == 0) {
+	and_media_data->dec_buf_size = (MAX_RX_WIDTH * MAX_RX_HEIGHT * 3 >> 1) +
+				       (MAX_RX_WIDTH);
+    }
+    and_media_data->dec_buf = (pj_uint8_t*)pj_pool_alloc(and_media_data->pool,
+                                                  and_media_data->dec_buf_size);
+    /* Need to update param back after values are negotiated */
+    pj_memcpy(codec_param, param, sizeof(*codec_param));
+
+    return PJ_SUCCESS;
+}
+
+static pj_status_t and_media_codec_close(pjmedia_vid_codec *codec)
+{
+    PJ_ASSERT_RETURN(codec, PJ_EINVAL);
+    PJ_UNUSED_ARG(codec);
+    return PJ_SUCCESS;
+}
+
+static pj_status_t and_media_codec_modify(pjmedia_vid_codec *codec,
+                                      const pjmedia_vid_codec_param *param)
+{
+    PJ_ASSERT_RETURN(codec && param, PJ_EINVAL);
+    PJ_UNUSED_ARG(codec);
+    PJ_UNUSED_ARG(param);
+    return PJ_EINVALIDOP;
+}
+
+static pj_status_t and_media_codec_get_param(pjmedia_vid_codec *codec,
+                                         pjmedia_vid_codec_param *param)
+{
+    struct and_media_codec_data *and_media_data;
+
+    PJ_ASSERT_RETURN(codec && param, PJ_EINVAL);
+
+    and_media_data = (and_media_codec_data*) codec->codec_data;
+    pj_memcpy(param, and_media_data->prm, sizeof(*param));
+
+    return PJ_SUCCESS;
+}
+
+static pj_status_t and_media_codec_encode_begin(pjmedia_vid_codec *codec,
+                                            const pjmedia_vid_encode_opt *opt,
+                                            const pjmedia_frame *input,
+                                            unsigned out_size,
+                                            pjmedia_frame *output,
+                                            pj_bool_t *has_more)
+{
+    struct and_media_codec_data *and_media_data;
+    unsigned i;
+    pj_ssize_t buf_idx;
+
+    PJ_ASSERT_RETURN(codec && input && out_size && output && has_more,
+                     PJ_EINVAL);
+
+    and_media_data = (and_media_codec_data*) codec->codec_data;
+
+    if (opt && opt->force_keyframe) {
+#if __ANDROID_API__ >=26
+	AMediaFormat *vid_fmt = NULL;
+	media_status_t am_status;
+
+	vid_fmt = AMediaFormat_new();
+	if (!vid_fmt) {
+	    return PJMEDIA_CODEC_EFAILED;
+	}
+	AMediaFormat_setInt32(vid_fmt, AND_MEDIA_KEY_REQUEST_SYNCF, 0);
+	am_status = AMediaCodec_setParameters(and_media_data->enc, vid_fmt);
+
+	if (am_status != AMEDIA_OK)
+	    PJ_LOG(4,(THIS_FILE, "Encoder setParameters failed %d", am_status));
+
+	AMediaFormat_delete(vid_fmt);
+#else
+	PJ_LOG(5, (THIS_FILE, "Encoder cannot be forced to send keyframe"));
+#endif
+    }
+
+    buf_idx = AMediaCodec_dequeueInputBuffer(and_media_data->enc,
+					     CODEC_DEQUEUE_TIMEOUT);
+    if (buf_idx >= 0) {
+	media_status_t am_status;
+	pj_size_t output_size;
+	pj_uint8_t *input_buf = AMediaCodec_getInputBuffer(and_media_data->enc,
+						    buf_idx, &output_size);
+	if (input_buf && output_size >= input->size) {
+	    pj_memcpy(input_buf, input->buf, input->size);
+	    am_status = AMediaCodec_queueInputBuffer(and_media_data->enc,
+				                buf_idx, 0, input->size, 0, 0);
+	    if (am_status != AMEDIA_OK) {
+		PJ_LOG(4, (THIS_FILE, "Encoder queueInputBuffer return %d",
+		           am_status));
+		goto on_return;
+	    }
+	} else {
+	    if (!input_buf) {
+		PJ_LOG(4,(THIS_FILE, "Encoder getInputBuffer "
+				     "returns no input buff"));
+	    } else {
+		PJ_LOG(4,(THIS_FILE, "Encoder getInputBuffer "
+				     "size: %d, expecting %d.",
+				     input_buf, output_size, input->size));
+	    }
+	    goto on_return;
+	}
+    } else {
+	PJ_LOG(4,(THIS_FILE, "Encoder dequeueInputBuffer failed[%d]", buf_idx));
+	goto on_return;
+    }
+
+    for (i = 0; i < CODEC_WAIT_RETRY; ++i) {
+	buf_idx = AMediaCodec_dequeueOutputBuffer(and_media_data->enc,
+						  &and_media_data->enc_buf_info,
+						  CODEC_DEQUEUE_TIMEOUT);
+	if (buf_idx == -1) {
+	    /* Timeout, wait until output buffer is availble. */
+	    PJ_LOG(5, (THIS_FILE, "Encoder dequeueOutputBuffer timeout[%d]",
+		       i+1));
+	    pj_thread_sleep(CODEC_THREAD_WAIT);
+	} else {
+	    break;
+	}
+    }
+
+    if (buf_idx >= 0) {
+        pj_size_t output_size;
+        pj_uint8_t *output_buf = AMediaCodec_getOutputBuffer(
+        						and_media_data->enc,
+                                                        buf_idx,
+                                                        &output_size);
+        if (!output_buf) {
+            PJ_LOG(4, (THIS_FILE, "Encoder failed getting output buffer, "
+		       "buffer size %d, offset %d, flags %d",
+		       and_media_data->enc_buf_info.size,
+		       and_media_data->enc_buf_info.offset,
+		       and_media_data->enc_buf_info.flags));
+            goto on_return;
+        }
+        and_media_data->enc_processed = 0;
+        and_media_data->enc_frame_whole = output_buf;
+        and_media_data->enc_output_buf_idx = buf_idx;
+        and_media_data->enc_frame_size = and_media_data->enc_buf_info.size;
+
+        if (and_media_codec[and_media_data->codec_idx].process_encode) {
+            pj_status_t status;
+
+            status = and_media_codec[and_media_data->codec_idx].process_encode(
+                                                                and_media_data);
+
+            if (status != PJ_SUCCESS)
+                goto on_return;
+        }
+
+        if(and_media_data->enc_buf_info.flags & AND_MEDIA_FRM_TYPE_KEYFRAME) {
+            output->bit_info |= PJMEDIA_VID_FRM_KEYFRAME;
+        }
+
+        if (and_media_data->whole) {
+            unsigned payload_size = 0;
+            unsigned start_data = 0;
+
+            *has_more = PJ_FALSE;
+
+            if ((and_media_data->prm->enc_fmt.id == PJMEDIA_FORMAT_H264) &&
+                (and_media_data->enc_buf_info.flags &
+                				   AND_MEDIA_FRM_TYPE_KEYFRAME))
+            {
+        	h264_codec_data *h264_data =
+        			     (h264_codec_data *)and_media_data->ex_data;
+        	start_data = h264_data->enc_sps_pps_len;
+                pj_memcpy(output->buf, h264_data->enc_sps_pps_buf,
+                	  h264_data->enc_sps_pps_len);
+            }
+
+            payload_size = and_media_data->enc_buf_info.size + start_data;
+
+            if (payload_size > out_size)
+                return PJMEDIA_CODEC_EFRMTOOSHORT;
+
+            output->type = PJMEDIA_FRAME_TYPE_VIDEO;
+            output->size = payload_size;
+            output->timestamp = input->timestamp;
+            pj_memcpy((pj_uint8_t*)output->buf+start_data,
+        	      and_media_data->enc_frame_whole,
+        	      and_media_data->enc_buf_info.size);
+
+	    AMediaCodec_releaseOutputBuffer(and_media_data->enc,
+					    buf_idx,
+					    0);
+
+            return PJ_SUCCESS;
+        }
+    } else {
+        if (buf_idx == -2) {
+	    int width, height, color_fmt, stride;
+
+	    /* Format change. */
+	    AMediaFormat *vid_fmt = AMediaCodec_getOutputFormat(
+							   and_media_data->enc);
+
+	    AMediaFormat_getInt32(vid_fmt, AND_MEDIA_KEY_WIDTH, &width);
+	    AMediaFormat_getInt32(vid_fmt, AND_MEDIA_KEY_HEIGHT, &height);
+	    AMediaFormat_getInt32(vid_fmt, AND_MEDIA_KEY_COLOR_FMT, &color_fmt);
+	    AMediaFormat_getInt32(vid_fmt, AND_MEDIA_KEY_STRIDE, &stride);
+	    PJ_LOG(5, (THIS_FILE, "Encoder detect new width %d, height %d, "
+		       "color_fmt 0x%X, stride %d buf_size %d",
+		       width, height, color_fmt, stride,
+		       and_media_data->enc_buf_info.size));
+
+	    AMediaFormat_delete(vid_fmt);
+        } else {
+	    PJ_LOG(4, (THIS_FILE, "Encoder dequeueOutputBuffer failed[%d]",
+		       buf_idx));
+        }
+        goto on_return;
+    }
+
+    return and_media_codec_encode_more(codec, out_size, output, has_more);
+
+on_return:
+    output->size = 0;
+    output->type = PJMEDIA_FRAME_TYPE_NONE;
+    *has_more = PJ_FALSE;
+    return PJ_SUCCESS;
+}
+
+static pj_status_t and_media_codec_encode_more(pjmedia_vid_codec *codec,
+                                           unsigned out_size,
+                                           pjmedia_frame *output,
+                                           pj_bool_t *has_more)
+{
+    struct and_media_codec_data *and_media_data;
+    pj_status_t status = PJ_SUCCESS;
+
+    PJ_ASSERT_RETURN(codec && out_size && output && has_more, PJ_EINVAL);
+
+    and_media_data = (and_media_codec_data*) codec->codec_data;
+
+    status = and_media_codec[and_media_data->codec_idx].encode_more(
+							    and_media_data,
+							    out_size, output,
+							    has_more);
+    if (!(*has_more)) {
+	AMediaCodec_releaseOutputBuffer(and_media_data->enc,
+					and_media_data->enc_output_buf_idx,
+					0);
+    }
+
+    return status;
+}
+
+static int write_yuv(pj_uint8_t *buf,
+                     unsigned dst_len,
+                     unsigned char* input,
+                     int stride_len,
+                     int iWidth,
+                     int iHeight)
+{
+    unsigned req_size;
+    pj_uint8_t *dst = buf;
+    pj_uint8_t *max = dst + dst_len;
+    int   i;
+    unsigned char*  pPtr = NULL;
+
+    req_size = (iWidth * iHeight) + (iWidth / 2 * iHeight / 2) +
+	       (iWidth / 2 * iHeight / 2);
+    if (dst_len < req_size)
+	return -1;
+
+    pPtr = input;
+    for (i = 0; i < iHeight && (dst + iWidth < max); i++) {
+	pj_memcpy(dst, pPtr, iWidth);
+	pPtr += stride_len;
+	dst += iWidth;
+    }
+
+    if (i < iHeight)
+	return -1;
+
+    iHeight = iHeight / 2;
+    iWidth = iWidth / 2;
+    for (i = 0; i < iHeight && (dst + iWidth <= max); i++) {
+	pj_memcpy(dst, pPtr, iWidth);
+	pPtr += stride_len/2;
+	dst += iWidth;
+    }
+
+    if (i < iHeight)
+	return -1;
+
+    for (i = 0; i < iHeight && (dst + iWidth <= max); i++) {
+	pj_memcpy(dst, pPtr, iWidth);
+	pPtr += stride_len/2;
+	dst += iWidth;
+    }
+
+    if (i < iHeight)
+	return -1;
+
+    return dst - buf;
+}
+
+static void and_media_get_input_buffer(
+				    struct and_media_codec_data *and_media_data)
+{
+    pj_ssize_t buf_idx = -1;
+
+    buf_idx = AMediaCodec_dequeueInputBuffer(and_media_data->dec,
+					     CODEC_DEQUEUE_TIMEOUT);
+
+    if (buf_idx < 0) {
+	PJ_LOG(4,(THIS_FILE, "Decoder dequeueInputBuffer failed return %d",
+		  buf_idx));
+
+	and_media_data->dec_input_buf = NULL;
+
+	if (buf_idx == -10000) {
+	    PJ_LOG(5, (THIS_FILE, "Resetting decoder"));
+	    AMediaCodec_stop(and_media_data->dec);
+	    AMediaCodec_delete(and_media_data->dec);
+	    and_media_data->dec = NULL;
+
+	    create_codec(and_media_data);
+	    if (and_media_data->dec)
+		configure_decoder(and_media_data);
+	}
+	return;
+    }
+
+    and_media_data->dec_input_buf_len = 0;
+    and_media_data->dec_input_buf_idx = buf_idx;
+    and_media_data->dec_input_buf = AMediaCodec_getInputBuffer(
+				       and_media_data->dec,
+				       buf_idx,
+				       &and_media_data->dec_input_buf_max_size);
+}
+
+static pj_status_t and_media_decode(pjmedia_vid_codec *codec,
+			        struct and_media_codec_data *and_media_data,
+			        pj_uint8_t *input_buf, unsigned buf_size,
+			        int buf_flag, pj_timestamp *input_ts,
+			        pj_bool_t write_output, pjmedia_frame *output)
+{
+    pj_ssize_t buf_idx = 0;
+    pj_status_t status = PJ_SUCCESS;
+    media_status_t am_status;
+
+    if ((and_media_data->dec_input_buf_max_size > 0) &&
+	(and_media_data->dec_input_buf_len + buf_size >
+         and_media_data->dec_input_buf_max_size))
+    {
+	am_status = AMediaCodec_queueInputBuffer(and_media_data->dec,
+					    and_media_data->dec_input_buf_idx,
+					    0,
+					    and_media_data->dec_input_buf_len,
+					    input_ts->u32.lo,
+					    buf_flag);
+	if (am_status != AMEDIA_OK) {
+	    PJ_LOG(4,(THIS_FILE, "Decoder queueInputBuffer idx[%d] return %d",
+		    and_media_data->dec_input_buf_idx, am_status));
+	    return status;
+	}
+	and_media_data->dec_input_buf = NULL;
+    }
+
+    if (and_media_data->dec_input_buf == NULL)
+    {
+	and_media_get_input_buffer(and_media_data);
+
+	if (and_media_data->dec_input_buf == NULL) {
+	    PJ_LOG(4,(THIS_FILE, "Decoder failed getting input buffer"));
+	    return status;
+	}
+    }
+    pj_memcpy(and_media_data->dec_input_buf + and_media_data->dec_input_buf_len,
+	      input_buf, buf_size);
+
+    and_media_data->dec_input_buf_len += buf_size;
+
+    if (!write_output)
+	return status;
+
+    am_status = AMediaCodec_queueInputBuffer(and_media_data->dec,
+					     and_media_data->dec_input_buf_idx,
+					     0,
+					     and_media_data->dec_input_buf_len,
+					     input_ts->u32.lo,
+					     buf_flag);
+    if (am_status != AMEDIA_OK) {
+	PJ_LOG(4,(THIS_FILE, "Decoder queueInputBuffer failed return %d",
+		  am_status));
+	and_media_data->dec_input_buf = NULL;
+	return status;
+    }
+    and_media_data->dec_input_buf_len += buf_size;
+
+    buf_idx = AMediaCodec_dequeueOutputBuffer(and_media_data->dec,
+					      &and_media_data->dec_buf_info,
+					      CODEC_DEQUEUE_TIMEOUT);
+
+    if (buf_idx >= 0) {
+	pj_size_t output_size;
+	int len;
+
+	pj_uint8_t *output_buf = AMediaCodec_getOutputBuffer(
+							and_media_data->dec,
+							buf_idx,
+							&output_size);
+	if (output_buf == NULL) {
+	    am_status = AMediaCodec_releaseOutputBuffer(and_media_data->dec,
+					    buf_idx,
+					    0);
+	    PJ_LOG(4,(THIS_FILE, "Decoder getOutputBuffer failed"));
+	    return status;
+	}
+	len = write_yuv((pj_uint8_t *)output->buf,
+			and_media_data->dec_buf_info.size,
+			output_buf,
+			and_media_data->dec_stride_len,
+			and_media_data->prm->dec_fmt.det.vid.size.w,
+			and_media_data->prm->dec_fmt.det.vid.size.h);
+
+	am_status = AMediaCodec_releaseOutputBuffer(and_media_data->dec,
+						    buf_idx,
+						    0);
+
+	if (len > 0) {
+	    if (!and_media_data->dec_has_output_frame) {
+		output->type = PJMEDIA_FRAME_TYPE_VIDEO;
+		output->size = len;
+		output->timestamp = *input_ts;
+
+		and_media_data->dec_has_output_frame = PJ_TRUE;
+	    }
+	} else {
+	    status = PJMEDIA_CODEC_EFRMTOOSHORT;
+	}
+    } else if (buf_idx == -2) {
+	int width, height, stride;
+	AMediaFormat *vid_fmt;
+	/* Get output format */
+	vid_fmt = AMediaCodec_getOutputFormat(and_media_data->dec);
+
+	AMediaFormat_getInt32(vid_fmt, AND_MEDIA_KEY_WIDTH, &width);
+	AMediaFormat_getInt32(vid_fmt, AND_MEDIA_KEY_HEIGHT, &height);
+	AMediaFormat_getInt32(vid_fmt, AND_MEDIA_KEY_STRIDE, &stride);
+
+	AMediaFormat_delete(vid_fmt);
+	and_media_data->dec_stride_len = stride;
+	if (width != and_media_data->prm->dec_fmt.det.vid.size.w ||
+	    height != and_media_data->prm->dec_fmt.det.vid.size.h)
+	{
+	    pjmedia_event event;
+
+	    and_media_data->prm->dec_fmt.det.vid.size.w = width;
+	    and_media_data->prm->dec_fmt.det.vid.size.h = height;
+
+	    PJ_LOG(4,(THIS_FILE, "Frame size changed to %dx%d",
+		      and_media_data->prm->dec_fmt.det.vid.size.w,
+		      and_media_data->prm->dec_fmt.det.vid.size.h));
+
+	    /* Broadcast format changed event */
+	    pjmedia_event_init(&event, PJMEDIA_EVENT_FMT_CHANGED,
+			       &output->timestamp, codec);
+	    event.data.fmt_changed.dir = PJMEDIA_DIR_DECODING;
+	    pjmedia_format_copy(&event.data.fmt_changed.new_fmt,
+				&and_media_data->prm->dec_fmt);
+	    pjmedia_event_publish(NULL, codec, &event,
+				  PJMEDIA_EVENT_PUBLISH_DEFAULT);
+	}
+    } else {
+	PJ_LOG(4,(THIS_FILE, "Decoder dequeueOutputBuffer failed [%d]",
+		  buf_idx));
+    }
+    return status;
+}
+
+static pj_status_t and_media_codec_decode(pjmedia_vid_codec *codec,
+                                      pj_size_t count,
+                                      pjmedia_frame packets[],
+                                      unsigned out_size,
+                                      pjmedia_frame *output)
+{
+    struct and_media_codec_data *and_media_data;
+    pj_status_t status = PJ_EINVAL;
+
+    PJ_ASSERT_RETURN(codec && count && packets && out_size && output,
+                     PJ_EINVAL);
+    PJ_ASSERT_RETURN(output->buf, PJ_EINVAL);
+
+    and_media_data = (and_media_codec_data*) codec->codec_data;
+    and_media_data->dec_has_output_frame = PJ_FALSE;
+    and_media_data->dec_input_buf = NULL;
+    and_media_data->dec_input_buf_len = 0;
+
+    if (and_media_codec[and_media_data->codec_idx].decode) {
+        status = and_media_codec[and_media_data->codec_idx].decode(codec, count,
+                                                           packets, out_size,
+                                                           output);
+    }
+    if (status != PJ_SUCCESS) {
+	return status;
+    }
+    if (!and_media_data->dec_has_output_frame) {
+	pjmedia_event event;
+
+	/* Broadcast missing keyframe event */
+	pjmedia_event_init(&event, PJMEDIA_EVENT_KEYFRAME_MISSING,
+			   &packets[0].timestamp, codec);
+	pjmedia_event_publish(NULL, codec, &event,
+			      PJMEDIA_EVENT_PUBLISH_DEFAULT);
+
+	PJ_LOG(4,(THIS_FILE, "Decoder couldn't produce output frame"));
+
+	output->type = PJMEDIA_FRAME_TYPE_NONE;
+	output->size = 0;
+	output->timestamp = packets[0].timestamp;
+    }
+    return PJ_SUCCESS;
+}
+
+#if PJMEDIA_HAS_AND_MEDIA_H264
+
+static pj_status_t open_h264(and_media_codec_data *and_media_data)
+{
+    pj_status_t status;
+    pjmedia_vid_codec_param *param = and_media_data->prm;
+    pjmedia_h264_packetizer_cfg  pktz_cfg;
+    pjmedia_vid_codec_h264_fmtp  h264_fmtp;
+    h264_codec_data *h264_data;
+
+    /* Parse remote fmtp */
+    pj_bzero(&h264_fmtp, sizeof(h264_fmtp));
+    status = pjmedia_vid_codec_h264_parse_fmtp(&param->enc_fmtp,
+                                               &h264_fmtp);
+    if (status != PJ_SUCCESS)
+        return status;
+
+    /* Apply SDP fmtp to format in codec param */
+    if (!param->ignore_fmtp) {
+        status = pjmedia_vid_codec_h264_apply_fmtp(param);
+        if (status != PJ_SUCCESS)
+            return status;
+    }
+    h264_data = PJ_POOL_ZALLOC_T(and_media_data->pool, h264_codec_data);
+    if (!h264_data)
+        return PJ_ENOMEM;
+
+    pj_bzero(&pktz_cfg, sizeof(pktz_cfg));
+    pktz_cfg.mtu = param->enc_mtu;
+    pktz_cfg.unpack_nal_start = 4;
+    /* Packetization mode */
+    if (h264_fmtp.packetization_mode == 0)
+        pktz_cfg.mode = PJMEDIA_H264_PACKETIZER_MODE_SINGLE_NAL;
+    else if (h264_fmtp.packetization_mode == 1)
+        pktz_cfg.mode = PJMEDIA_H264_PACKETIZER_MODE_NON_INTERLEAVED;
+    else
+        return PJ_ENOTSUP;
+
+    /* Android H264 only supports Non Interleaved mode. */
+    pktz_cfg.mode = PJMEDIA_H264_PACKETIZER_MODE_NON_INTERLEAVED;
+    status = pjmedia_h264_packetizer_create(and_media_data->pool, &pktz_cfg,
+                                            &h264_data->pktz);
+    if (status != PJ_SUCCESS)
+        return status;
+
+    and_media_data->ex_data = h264_data;
+    and_media_data->dec_buf_size = (MAX_RX_WIDTH * MAX_RX_HEIGHT * 3 >> 1) +
+				   (MAX_RX_WIDTH);
+
+    /* If available, use the "sprop-parameter-sets" fmtp from remote SDP
+     * to create the decoder.
+     */
+    if (h264_fmtp.sprop_param_sets_len) {
+        const pj_uint8_t start_code[3] = { 0, 0, 1 };
+        const int code_size = PJ_ARRAY_SIZE(start_code);
+        const pj_uint8_t med_start_code[4] = { 0, 0, 0, 1 };
+        const int med_code_size = PJ_ARRAY_SIZE(med_start_code);
+        unsigned i, j;
+
+        for (i = h264_fmtp.sprop_param_sets_len - code_size;
+             i >= code_size; i--)
+        {
+            pj_bool_t found = PJ_TRUE;
+            for (j = 0; j < code_size; j++) {
+                if (h264_fmtp.sprop_param_sets[i + j] != start_code[j]) {
+                    found = PJ_FALSE;
+                    break;
+                }
+            }
+        }
+
+        if (i >= code_size) {
+            h264_data->dec_sps_len = i + med_code_size - code_size;
+            h264_data->dec_pps_len = h264_fmtp.sprop_param_sets_len +
+                med_code_size - code_size - i;
+
+            h264_data->dec_sps_buf = (pj_uint8_t *)pj_pool_alloc(
+        			and_media_data->pool, h264_data->dec_sps_len);
+            h264_data->dec_pps_buf = (pj_uint8_t *)pj_pool_alloc(
+        			and_media_data->pool, h264_data->dec_pps_len);
+
+            pj_memcpy(h264_data->dec_sps_buf, med_start_code,
+                      med_code_size);
+            pj_memcpy(h264_data->dec_sps_buf + med_code_size,
+                      &h264_fmtp.sprop_param_sets[code_size],
+                      h264_data->dec_sps_len - med_code_size);
+            pj_memcpy(h264_data->dec_pps_buf, med_start_code,
+                      med_code_size);
+            pj_memcpy(h264_data->dec_pps_buf + med_code_size,
+                      &h264_fmtp.sprop_param_sets[i + code_size],
+                      h264_data->dec_pps_len - med_code_size);
+        }
+    }
+    return status;
+}
+
+static pj_status_t process_encode_h264(and_media_codec_data *and_media_data)
+{
+    pj_status_t status = PJ_SUCCESS;
+    h264_codec_data *h264_data;
+
+    h264_data = (h264_codec_data *)and_media_data->ex_data;
+    if (and_media_data->enc_buf_info.flags & AND_MEDIA_FRM_TYPE_CONFIG) {
+
+        /*
+	* Config data or SPS+PPS. Update the SPS and PPS buffer,
+	* this will be sent later when sending Keyframe.
+	*/
+	h264_data->enc_sps_pps_len = PJ_MIN(and_media_data->enc_buf_info.size,
+                                        sizeof(h264_data->enc_sps_pps_buf));
+        pj_memcpy(h264_data->enc_sps_pps_buf, and_media_data->enc_frame_whole,
+        	  h264_data->enc_sps_pps_len);
+
+        AMediaCodec_releaseOutputBuffer(and_media_data->enc,
+                                        and_media_data->enc_output_buf_idx,
+                                        0);
+
+        return PJ_EIGNORED;
+    }
+    if (and_media_data->enc_buf_info.flags & AND_MEDIA_FRM_TYPE_KEYFRAME) {
+	h264_data->enc_sps_pps_ex = PJ_TRUE;
+        and_media_data->enc_frame_size = h264_data->enc_sps_pps_len;
+    } else {
+	h264_data->enc_sps_pps_ex = PJ_FALSE;
+    }
+
+    return status;
+}
+
+static pj_status_t encode_more_h264(and_media_codec_data *and_media_data,
+				    unsigned out_size,
+				    pjmedia_frame *output,
+				    pj_bool_t *has_more)
+{
+    const pj_uint8_t *payload;
+    pj_size_t payload_len;
+    pj_status_t status;
+    pj_uint8_t *data_buf = NULL;
+    h264_codec_data *h264_data;
+
+    h264_data = (h264_codec_data *)and_media_data->ex_data;
+    if (h264_data->enc_sps_pps_ex) {
+	data_buf = h264_data->enc_sps_pps_buf;
+    } else {
+	data_buf = and_media_data->enc_frame_whole;
+    }
+    /* We have outstanding frame in packetizer */
+    status = pjmedia_h264_packetize(h264_data->pktz,
+				    data_buf,
+				    and_media_data->enc_frame_size,
+				    &and_media_data->enc_processed,
+				    &payload, &payload_len);
+    if (status != PJ_SUCCESS) {
+	/* Reset */
+	and_media_data->enc_frame_size = and_media_data->enc_processed = 0;
+	*has_more = (and_media_data->enc_processed <
+		     and_media_data->enc_frame_size);
+
+	if (!(*has_more)) {
+	    AMediaCodec_releaseOutputBuffer(and_media_data->enc,
+					    and_media_data->enc_output_buf_idx,
+					    0);
+	}
+	PJ_PERROR(3,(THIS_FILE, status, "pjmedia_h264_packetize() error"));
+	return status;
+    }
+
+    PJ_ASSERT_RETURN(payload_len <= out_size, PJMEDIA_CODEC_EFRMTOOSHORT);
+
+    output->type = PJMEDIA_FRAME_TYPE_VIDEO;
+    pj_memcpy(output->buf, payload, payload_len);
+    output->size = payload_len;
+
+    if (and_media_data->enc_processed >= and_media_data->enc_frame_size) {
+	h264_codec_data *h264_data = (h264_codec_data *)and_media_data->ex_data;
+
+	if (h264_data->enc_sps_pps_ex) {
+	    *has_more = PJ_TRUE;
+	    h264_data->enc_sps_pps_ex = PJ_FALSE;
+	    and_media_data->enc_processed = 0;
+	    and_media_data->enc_frame_size = and_media_data->enc_buf_info.size;
+	} else {
+	    *has_more = PJ_FALSE;
+	    AMediaCodec_releaseOutputBuffer(and_media_data->enc,
+					    and_media_data->enc_output_buf_idx,
+					    0);
+	}
+    } else {
+	*has_more = PJ_TRUE;
+    }
+
+    return PJ_SUCCESS;
+}
+
+static pj_status_t decode_h264(pjmedia_vid_codec *codec,
+			       pj_size_t count,
+			       pjmedia_frame packets[],
+			       unsigned out_size,
+			       pjmedia_frame *output)
+{
+    struct and_media_codec_data *and_media_data;
+    const pj_uint8_t start_code[] = { 0, 0, 0, 1 };
+    const int code_size = PJ_ARRAY_SIZE(start_code);
+    unsigned buf_pos, whole_len = 0;
+    unsigned i, frm_cnt;
+    pj_status_t status;
+
+    PJ_ASSERT_RETURN(codec && count && packets && out_size && output,
+                     PJ_EINVAL);
+    PJ_ASSERT_RETURN(output->buf, PJ_EINVAL);
+
+    and_media_data = (and_media_codec_data*) codec->codec_data;
+
+    /*
+     * Step 1: unpacketize the packets/frames
+     */
+    whole_len = 0;
+    if (and_media_data->whole) {
+	for (i=0; i<count; ++i) {
+	    if (whole_len + packets[i].size > and_media_data->dec_buf_size) {
+		PJ_LOG(4,(THIS_FILE, "Decoding buffer overflow [1]"));
+		return PJMEDIA_CODEC_EFRMTOOSHORT;
+	    }
+
+	    pj_memcpy( and_media_data->dec_buf + whole_len,
+	               (pj_uint8_t*)packets[i].buf,
+	               packets[i].size);
+	    whole_len += packets[i].size;
+	}
+
+    } else {
+	h264_codec_data *h264_data = (h264_codec_data *)and_media_data->ex_data;
+
+	for (i=0; i<count; ++i) {
+
+	    if (whole_len + packets[i].size + code_size >
+                and_media_data->dec_buf_size)
+	    {
+		PJ_LOG(4,(THIS_FILE, "Decoding buffer overflow [2]"));
+		return PJMEDIA_CODEC_EFRMTOOSHORT;
+	    }
+
+	    status = pjmedia_h264_unpacketize( h264_data->pktz,
+					       (pj_uint8_t*)packets[i].buf,
+					       packets[i].size,
+					       and_media_data->dec_buf,
+					       and_media_data->dec_buf_size,
+					       &whole_len);
+	    if (status != PJ_SUCCESS) {
+		PJ_PERROR(4,(THIS_FILE, status, "Unpacketize error"));
+		continue;
+	    }
+	}
+    }
+
+    if (whole_len + code_size > and_media_data->dec_buf_size ||
+    	whole_len <= code_size + 1)
+    {
+	PJ_LOG(4,(THIS_FILE, "Decoding buffer overflow or unpacketize error "
+			     "size: %d, buffer: %d", whole_len,
+			     and_media_data->dec_buf_size));
+	return PJMEDIA_CODEC_EFRMTOOSHORT;
+    }
+
+    /* Dummy NAL sentinel */
+    pj_memcpy(and_media_data->dec_buf + whole_len, start_code, code_size);
+
+    /*
+     * Step 2: parse the individual NAL and give to decoder
+     */
+    buf_pos = 0;
+    for ( frm_cnt=0; ; ++frm_cnt) {
+	pj_uint32_t frm_size;
+	pj_bool_t write_output = PJ_FALSE;
+	unsigned char *start;
+
+	for (i = code_size - 1; buf_pos + i < whole_len; i++) {
+	    if (and_media_data->dec_buf[buf_pos + i] == 0 &&
+		and_media_data->dec_buf[buf_pos + i + 1] == 0 &&
+		and_media_data->dec_buf[buf_pos + i + 2] == 0 &&
+		and_media_data->dec_buf[buf_pos + i + 3] == 1)
+	    {
+		break;
+	    }
+	}
+
+	frm_size = i;
+	start = and_media_data->dec_buf + buf_pos;
+	write_output = (buf_pos + frm_size >= whole_len);
+
+	status = and_media_decode(codec, and_media_data, start, frm_size, 0,
+		              &packets[0].timestamp, write_output, output);
+	if (status != PJ_SUCCESS)
+	    return status;
+
+	if (write_output)
+	    break;
+
+	buf_pos += frm_size;
+    }
+
+    return PJ_SUCCESS;
+}
+
+#endif
+
+#if PJMEDIA_HAS_AND_MEDIA_VP8 || PJMEDIA_HAS_AND_MEDIA_VP9
+
+static pj_status_t open_vpx(and_media_codec_data *and_media_data)
+{
+    vpx_codec_data *vpx_data;
+    pjmedia_vid_codec_vpx_fmtp vpx_fmtp;
+    pjmedia_vpx_packetizer_cfg pktz_cfg;
+    pj_status_t status = PJ_SUCCESS;
+    unsigned max_res = MAX_RX_WIDTH;
+
+    if (!and_media_data->prm->ignore_fmtp) {
+        status = pjmedia_vid_codec_vpx_apply_fmtp(and_media_data->prm);
+	if (status != PJ_SUCCESS)
+	    return status;
+    }
+
+    vpx_data = PJ_POOL_ZALLOC_T(and_media_data->pool, vpx_codec_data);
+    if (!vpx_data)
+        return PJ_ENOMEM;
+
+    /* Parse local fmtp */
+    status = pjmedia_vid_codec_vpx_parse_fmtp(&and_media_data->prm->dec_fmtp,
+					      &vpx_fmtp);
+    if (status != PJ_SUCCESS)
+	return status;
+
+    if (vpx_fmtp.max_fs > 0) {
+    	max_res = ((int)pj_isqrt(vpx_fmtp.max_fs * 8)) * 16;
+    }
+    and_media_data->dec_buf_size = (max_res * max_res * 3 >> 1) + (max_res);
+
+    pj_bzero(&pktz_cfg, sizeof(pktz_cfg));
+    pktz_cfg.mtu = and_media_data->prm->enc_mtu;
+    pktz_cfg.fmt_id = and_media_data->prm->enc_fmt.id;
+
+    status = pjmedia_vpx_packetizer_create(and_media_data->pool, &pktz_cfg,
+                                            &vpx_data->pktz);
+    if (status != PJ_SUCCESS)
+        return status;
+
+    and_media_data->ex_data = vpx_data;
+
+    return status;
+}
+
+static pj_status_t encode_more_vpx(and_media_codec_data *and_media_data,
+				   unsigned out_size,
+				   pjmedia_frame *output,
+				   pj_bool_t *has_more)
+{
+    pj_status_t status = PJ_SUCCESS;
+    struct vpx_codec_data *vpx_data = (vpx_codec_data *)and_media_data->ex_data;
+
+    PJ_ASSERT_RETURN(and_media_data && out_size && output && has_more,
+                     PJ_EINVAL);
+
+    if ((and_media_data->prm->enc_fmt.id != PJMEDIA_FORMAT_VP8) &&
+	(and_media_data->prm->enc_fmt.id != PJMEDIA_FORMAT_VP9))
+    {
+    	*has_more = PJ_FALSE;
+    	output->size = 0;
+    	output->type = PJMEDIA_FRAME_TYPE_NONE;
+
+	return PJ_SUCCESS;
+    }
+
+    if (and_media_data->enc_processed < and_media_data->enc_frame_size) {
+    	unsigned payload_desc_size = 1;
+    	pj_size_t payload_len = out_size;
+    	pj_uint8_t *p = (pj_uint8_t *)output->buf;
+        pj_bool_t is_keyframe = and_media_data->enc_buf_info.flags &
+        		        AND_MEDIA_FRM_TYPE_KEYFRAME;
+
+    	status = pjmedia_vpx_packetize(vpx_data->pktz,
+    				       and_media_data->enc_frame_size,
+				       &and_media_data->enc_processed,
+				       is_keyframe,
+				       &p,
+				       &payload_len);
+    	if (status != PJ_SUCCESS) {
+    	    return status;
+    	}
+        pj_memcpy(p + payload_desc_size,
+              (and_media_data->enc_frame_whole + and_media_data->enc_processed),
+              payload_len);
+        output->size = payload_len + payload_desc_size;
+        if (is_keyframe) {
+            output->bit_info |= PJMEDIA_VID_FRM_KEYFRAME;
+        }
+        and_media_data->enc_processed += payload_len;
+        *has_more = (and_media_data->enc_processed <
+        	     and_media_data->enc_frame_size);
+    }
+
+    return status;
+}
+
+static pj_status_t decode_vpx(pjmedia_vid_codec *codec,
+			      pj_size_t count,
+			      pjmedia_frame packets[],
+			      unsigned out_size,
+			      pjmedia_frame *output)
+{
+    unsigned i, whole_len = 0;
+    pj_status_t status;
+    and_media_codec_data *and_media_data =
+				      (and_media_codec_data*) codec->codec_data;
+    struct vpx_codec_data *vpx_data = (vpx_codec_data *)and_media_data->ex_data;
+
+    PJ_ASSERT_RETURN(codec && count && packets && out_size && output,
+                     PJ_EINVAL);
+    PJ_ASSERT_RETURN(output->buf, PJ_EINVAL);
+
+    whole_len = 0;
+    if (and_media_data->whole) {
+	for (i = 0; i < count; ++i) {
+	    if (whole_len + packets[i].size > and_media_data->dec_buf_size) {
+		PJ_LOG(4,(THIS_FILE, "Decoding buffer overflow [1]"));
+		return PJMEDIA_CODEC_EFRMTOOSHORT;
+	    }
+
+	    pj_memcpy( and_media_data->dec_buf + whole_len,
+	               (pj_uint8_t*)packets[i].buf,
+	               packets[i].size);
+	    whole_len += packets[i].size;
+	}
+	status = and_media_decode(codec, and_media_data,
+				  and_media_data->dec_buf, whole_len, 0,
+				  &packets[0].timestamp, PJ_TRUE, output);
+
+	if (status != PJ_SUCCESS)
+	    return status;
+
+    } else {
+    	for (i = 0; i < count; ++i) {
+    	    unsigned desc_len;
+    	    unsigned packet_size = packets[i].size;
+    	    pj_status_t status;
+    	    pj_bool_t write_output;
+
+            status = pjmedia_vpx_unpacketize(vpx_data->pktz,
+        				     (pj_uint8_t *)packets[i].buf,
+                                             packet_size,
+                                             &desc_len);
+    	    if (status != PJ_SUCCESS) {
+	    	PJ_LOG(4,(THIS_FILE, "Unpacketize error packet size[%d]",
+	    		  packet_size));
+	    	return status;
+    	    }
+
+    	    packet_size -= desc_len;
+    	    if (whole_len + packet_size > and_media_data->dec_buf_size) {
+	    	PJ_LOG(4,(THIS_FILE, "Decoding buffer overflow [2]"));
+	    	return PJMEDIA_CODEC_EFRMTOOSHORT;
+            }
+
+    	    write_output = (i == count - 1);
+
+    	    status = and_media_decode(codec, and_media_data,
+    				  (pj_uint8_t *)packets[i].buf + desc_len,
+    				  packet_size, 0, &packets[0].timestamp,
+    				  write_output, output);
+    	    if (status != PJ_SUCCESS)
+    		return status;
+
+	    whole_len += packet_size;
+    	}
+    }
+    return PJ_SUCCESS;
+}
+
+#endif
+
+#endif	/* PJMEDIA_HAS_ANDROID_MEDIACODEC */

--- a/pjmedia/src/pjmedia-codec/audio_codecs.c
+++ b/pjmedia/src/pjmedia-codec/audio_codecs.c
@@ -44,6 +44,14 @@ pjmedia_codec_register_audio_codecs(pjmedia_endpt *endpt,
 
     PJ_ASSERT_RETURN(c->ilbc.mode==20 || c->ilbc.mode==30, PJ_EINVAL);
 
+#if PJMEDIA_HAS_ANDROID_MEDIACODEC
+    /* Register Android MediaCodec */
+    status = pjmedia_codec_and_media_aud_init(endpt);
+    if (status != PJ_SUCCESS) {
+	return status;
+    }
+#endif
+
 #if PJMEDIA_HAS_PASSTHROUGH_CODECS
     status = pjmedia_codec_passthrough_init2(endpt, &c->passthrough.setting);
     if (status != PJ_SUCCESS)

--- a/pjmedia/src/pjmedia-codec/vpx.c
+++ b/pjmedia/src/pjmedia-codec/vpx.c
@@ -30,6 +30,8 @@
 #   pragma comment( lib, "vpx.lib")
 #endif
 
+#include <pjmedia-codec/vpx_packetizer.h>
+
 /* VPX */
 #include <vpx/vpx_encoder.h>
 #include <vpx/vpx_decoder.h>
@@ -142,6 +144,7 @@ typedef struct vpx_codec_data
     pj_pool_t			*pool;
     pjmedia_vid_codec_param	*prm;
     pj_bool_t			 whole;
+    pjmedia_vpx_packetizer	*pktz;
 
     /* Encoder */
     vpx_codec_iface_t 		*(*enc_if)();
@@ -401,6 +404,7 @@ static pj_status_t vpx_codec_open(pjmedia_vid_codec *codec,
     pjmedia_vid_codec_vpx_fmtp   vpx_fmtp;
     vpx_codec_enc_cfg_t cfg;
     vpx_codec_err_t res;
+    pjmedia_vpx_packetizer_cfg  pktz_cfg;
     unsigned max_res = MAX_RX_RES;
     pj_status_t	status;
 
@@ -496,6 +500,15 @@ static pj_status_t vpx_codec_open(pjmedia_vid_codec *codec,
 
     /* Need to update param back after values are negotiated */
     pj_memcpy(codec_param, param, sizeof(*codec_param));
+
+    pj_bzero(&pktz_cfg, sizeof(pktz_cfg));
+    pktz_cfg.mtu = param->enc_mtu;
+    pktz_cfg.fmt_id = param->enc_fmt.id;
+
+    status = pjmedia_vpx_packetizer_create(vpx_data->pool, &pktz_cfg,
+                                           &vpx_data->pktz);
+    if (status != PJ_SUCCESS)
+        return status;
 
     return PJ_SUCCESS;
 }
@@ -636,6 +649,7 @@ static pj_status_t vpx_codec_encode_more(pjmedia_vid_codec *codec,
                                          pj_bool_t *has_more)
 {
     struct vpx_codec_data *vpx_data;
+    pj_status_t status = PJ_SUCCESS;
 
     PJ_ASSERT_RETURN(codec && out_size && output && has_more,
                      PJ_EINVAL);
@@ -644,155 +658,35 @@ static pj_status_t vpx_codec_encode_more(pjmedia_vid_codec *codec,
     
     if (vpx_data->enc_processed < vpx_data->enc_frame_size) {
     	unsigned payload_desc_size = 1;
-        unsigned max_size = vpx_data->prm->enc_mtu - payload_desc_size;
-        unsigned remaining_size = vpx_data->enc_frame_size -
-        			  vpx_data->enc_processed;
-        unsigned payload_len = PJ_MIN(remaining_size, max_size);
-        pj_uint8_t *p = (pj_uint8_t *)output->buf;
+    	pj_size_t payload_len = out_size;
+    	pj_uint8_t *p = (pj_uint8_t *)output->buf;
 
-	if (payload_len + payload_desc_size > out_size)
-	    return PJMEDIA_CODEC_EFRMTOOSHORT;
+    	status = pjmedia_vpx_packetize(vpx_data->pktz,
+				       vpx_data->enc_frame_size,
+				       &vpx_data->enc_processed,
+				       vpx_data->enc_frame_is_keyframe,
+				       &p,
+				       &payload_len);
 
+    	if (status != PJ_SUCCESS) {
+    	    return status;
+    	}
+        pj_memcpy(p + payload_desc_size,
+        	  (vpx_data->enc_frame_whole + vpx_data->enc_processed),
+        	  payload_len);
+        output->size = payload_len + payload_desc_size;
         output->timestamp = vpx_data->ets;
         output->type = PJMEDIA_FRAME_TYPE_VIDEO;
         output->bit_info = 0;
         if (vpx_data->enc_frame_is_keyframe) {
             output->bit_info |= PJMEDIA_VID_FRM_KEYFRAME;
         }
-
-        /* Set payload header */
-        p[0] = 0;
-        if (vpx_data->prm->enc_fmt.id == PJMEDIA_FORMAT_VP8) {
-	    /* Set N: Non-reference frame */
-            if (!vpx_data->enc_frame_is_keyframe) p[0] |= 0x20;
-            /* Set S: Start of VP8 partition. */
-            if (vpx_data->enc_processed == 0) p[0] |= 0x10;
-        } else if (vpx_data->prm->enc_fmt.id == PJMEDIA_FORMAT_VP9) {
-	    /* Set P: Inter-picture predicted frame */
-            if (!vpx_data->enc_frame_is_keyframe) p[0] |= 0x40;
-            /* Set B: Start of a frame */
-            if (vpx_data->enc_processed == 0) p[0] |= 0x8;
-            /* Set E: End of a frame */
-            if (vpx_data->enc_processed + payload_len ==
-            	vpx_data->enc_frame_size)
-            {
-	    	p[0] |= 0x4;
-	    }
-	}
-
-        pj_memcpy(p + payload_desc_size,
-        	  (vpx_data->enc_frame_whole + vpx_data->enc_processed),
-        	  payload_len);
-        output->size = payload_len + payload_desc_size;
-
         vpx_data->enc_processed += payload_len;
         *has_more = (vpx_data->enc_processed < vpx_data->enc_frame_size);
     }
 
-    return PJ_SUCCESS;
+    return status;
 }
-
-
-static pj_status_t vpx_unpacketize(struct vpx_codec_data *vpx_data,
-				   const pj_uint8_t *buf,
-                                   pj_size_t   packet_size,
-				   unsigned   *p_desc_len)
-{
-    unsigned desc_len = 1;
-    pj_uint8_t *p = (pj_uint8_t *)buf;
-
-#define INC_DESC_LEN() {if (++desc_len >= packet_size) return PJ_ETOOSMALL;}
-
-    if (packet_size <= desc_len) return PJ_ETOOSMALL;
-
-    if (vpx_data->prm->enc_fmt.id == PJMEDIA_FORMAT_VP8) {
-        /*  0 1 2 3 4 5 6 7
-         * +-+-+-+-+-+-+-+-+
-         * |X|R|N|S|R| PID | (REQUIRED)
-         */
-	/* X: Extended control bits present. */
-	if (p[0] & 0x80) {
-	    INC_DESC_LEN();
-	    /* |I|L|T|K| RSV   | */
-	    /* I: PictureID present. */
-	    if (p[1] & 0x80) {
-	    	INC_DESC_LEN();
-	    	/* If M bit is set, the PID field MUST contain 15 bits. */
-	    	if (p[2] & 0x80) INC_DESC_LEN();
-	    }
-	    /* L: TL0PICIDX present. */
-	    if (p[1] & 0x40) INC_DESC_LEN();
-	    /* T: TID present or K: KEYIDX present. */
-	    if ((p[1] & 0x20) || (p[1] & 0x10)) INC_DESC_LEN();
-	}
-
-    } else if (vpx_data->prm->enc_fmt.id == PJMEDIA_FORMAT_VP9) {
-        /*  0 1 2 3 4 5 6 7
-         * +-+-+-+-+-+-+-+-+
-         * |I|P|L|F|B|E|V|-| (REQUIRED)
-         */
-        /* I: Picture ID (PID) present. */
-	if (p[0] & 0x80) {
-	    INC_DESC_LEN();
-	    /* If M bit is set, the PID field MUST contain 15 bits. */
-	    if (p[1] & 0x80) INC_DESC_LEN();
-	}
-	/* L: Layer indices present. */
-	if (p[0] & 0x20) {
-	    INC_DESC_LEN();
-	    if (!(p[0] & 0x10)) INC_DESC_LEN();
-	}
-	/* F: Flexible mode.
-	 * I must also be set to 1, and if P is set, there's up to 3
-	 * reference index.
-	 */
-	if ((p[0] & 0x10) && (p[0] & 0x80) && (p[0] & 0x40)) {
-	    unsigned char *q = p + desc_len;
-
-	    INC_DESC_LEN();
-	    if (*q & 0x1) {
-	    	q++;
-	    	INC_DESC_LEN();
-	    	if (*q & 0x1) {
-	    	    q++;
-	    	    INC_DESC_LEN();
-	    	}
-	    }
-	}
-	/* V: Scalability structure (SS) data present. */
-	if (p[0] & 0x2) {
-	    unsigned char *q = p + desc_len;
-	    unsigned N_S = (*q >> 5) + 1;
-	    
-	    INC_DESC_LEN();
-	    /* Y: Each spatial layer's frame resolution present. */
-	    if (*q & 0x10) desc_len += N_S * 4;
-	    
-	    /* G: PG description present flag. */
-	    if (*q & 0x8) {
-	    	unsigned j;
-	    	unsigned N_G = *(p + desc_len);
-
-	    	INC_DESC_LEN();
-	    	for (j = 0; j< N_G; j++) {
-	    	    unsigned R;
-
-	    	    q = p + desc_len;
-	    	    INC_DESC_LEN();
-	    	    R = (*q & 0x0F) >> 2;
-	    	    desc_len += R;
-	    	    if (desc_len >= packet_size)
-	    	    	return PJ_ETOOSMALL;
-	    	}
-	    }
-	}
-    }
-#undef INC_DESC_LEN
-
-    *p_desc_len = desc_len;
-    return PJ_SUCCESS;
-}
-
 
 static pj_status_t vpx_codec_decode_(pjmedia_vid_codec *codec,
                                      pj_size_t count,
@@ -837,20 +731,20 @@ static pj_status_t vpx_codec_decode_(pjmedia_vid_codec *codec,
     	    unsigned desc_len;
     	    unsigned packet_size = packets[i].size;
     	    pj_status_t status;
-    	
-    	    status = vpx_unpacketize(vpx_data, packets[i].buf, packet_size,
-    				     &desc_len);
+
+            status = pjmedia_vpx_unpacketize(vpx_data->pktz, packets[i].buf,
+                                             packet_size, &desc_len);
     	    if (status != PJ_SUCCESS) {
 	    	PJ_LOG(4,(THIS_FILE, "Unpacketize error"));
 	    	return status;
     	    }
 
-    	    packet_size -= desc_len;	
+	    packet_size -= desc_len;
     	    if (whole_len + packet_size > vpx_data->dec_buf_size) {
 	    	PJ_LOG(4,(THIS_FILE, "Decoding buffer overflow [2]"));
 	    	return PJMEDIA_CODEC_EFRMTOOSHORT;
             }
-        
+
 	    pj_memcpy(vpx_data->dec_buf + whole_len,
 		      (char *)packets[i].buf + desc_len, packet_size);
 	    whole_len += packet_size;

--- a/pjmedia/src/pjmedia-codec/vpx_packetizer.c
+++ b/pjmedia/src/pjmedia-codec/vpx_packetizer.c
@@ -1,0 +1,225 @@
+/* 
+ * Copyright (C) 2020 Teluu Inc. (http://www.teluu.com)
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA 
+ */
+#include <pjmedia-codec/vpx_packetizer.h>
+#include <pjmedia/errno.h>
+#include <pjmedia/types.h>
+#include <pjmedia/vid_codec_util.h>
+#include <pj/assert.h>
+#include <pj/errno.h>
+#include <pj/log.h>
+#include <pj/pool.h>
+#include <pj/string.h>
+
+
+#if defined(PJMEDIA_HAS_VIDEO) && (PJMEDIA_HAS_VIDEO != 0)
+
+#define THIS_FILE		"vpx_packetizer.c"
+
+/* VPX packetizer definition */
+struct pjmedia_vpx_packetizer
+{
+    /* Current settings */
+    pjmedia_vpx_packetizer_cfg cfg;
+};
+
+/*
+ * Initialize VPX packetizer.
+ */
+PJ_DEF(void) pjmedia_vpx_packetizer_cfg_default(pjmedia_vpx_packetizer_cfg *cfg)
+{
+    pj_bzero(cfg, sizeof(*cfg));
+
+    cfg->fmt_id = PJMEDIA_FORMAT_VP8;
+    cfg->mtu =PJMEDIA_MAX_VID_PAYLOAD_SIZE;
+}
+
+/*
+ * Create vpx packetizer.
+ */
+PJ_DEF(pj_status_t) pjmedia_vpx_packetizer_create(
+				pj_pool_t *pool,
+				const pjmedia_vpx_packetizer_cfg *cfg,
+				pjmedia_vpx_packetizer **p)
+{
+    pjmedia_vpx_packetizer *p_;
+
+    PJ_ASSERT_RETURN(pool && p, PJ_EINVAL);
+
+    if (cfg && cfg->fmt_id != PJMEDIA_FORMAT_VP8 &&
+	cfg->fmt_id != PJMEDIA_FORMAT_VP9)
+    {
+	return PJ_ENOTSUP;
+    }
+
+    p_ = PJ_POOL_ZALLOC_T(pool, pjmedia_vpx_packetizer);
+    if (cfg) {
+	pj_memcpy(&p_->cfg, cfg, sizeof(*cfg));
+    } else {
+	pjmedia_vpx_packetizer_cfg_default(&p_->cfg);
+    }
+    *p = p_;
+
+    return PJ_SUCCESS;
+}
+
+/*
+ * Generate an RTP payload from H.264 frame bitstream, in-place processing.
+ */
+PJ_DEF(pj_status_t) pjmedia_vpx_packetize(const pjmedia_vpx_packetizer *pktz,
+					  pj_size_t bits_len,
+                                          unsigned *bits_pos,
+                                          pj_bool_t is_keyframe,
+                                          pj_uint8_t **payload,
+                                          pj_size_t *payload_len)
+{
+    unsigned payload_desc_size = 1;
+    unsigned max_size = pktz->cfg.mtu - payload_desc_size;
+    unsigned remaining_size = bits_len - *bits_pos;
+    unsigned out_size = *payload_len;
+    pj_uint8_t *bits = *payload;
+
+    *payload_len = PJ_MIN(remaining_size, max_size);
+    if (*payload_len + payload_desc_size > out_size)
+	return PJMEDIA_CODEC_EFRMTOOSHORT;
+
+    /* Set payload header */
+    bits[0] = 0;
+    if (pktz->cfg.fmt_id == PJMEDIA_FORMAT_VP8) {
+	/* Set N: Non-reference frame */
+        if (!is_keyframe) bits[0] |= 0x20;
+        /* Set S: Start of VP8 partition. */
+        if (*bits_pos == 0) bits[0] |= 0x10;
+    } else if (pktz->cfg.fmt_id == PJMEDIA_FORMAT_VP9) {
+	/* Set P: Inter-picture predicted frame */
+        if (!is_keyframe) bits[0] |= 0x40;
+        /* Set B: Start of a frame */
+        if (*bits_pos == 0) bits[0] |= 0x8;
+        /* Set E: End of a frame */
+        if (*bits_pos + *payload_len == bits_len) {
+            bits[0] |= 0x4;
+	}
+    }
+    return PJ_SUCCESS;
+}
+
+
+/*
+ * Append RTP payload to a VPX picture bitstream
+ */
+PJ_DEF(pj_status_t) pjmedia_vpx_unpacketize(pjmedia_vpx_packetizer *pktz,
+					    const pj_uint8_t *payload,
+                                            pj_size_t payload_len,
+					    unsigned  *payload_desc_len)
+{
+    unsigned desc_len = 1;
+    pj_uint8_t *p = (pj_uint8_t *)payload;
+
+#define INC_DESC_LEN() {if (++desc_len >= payload_len) return PJ_ETOOSMALL;}
+
+    if (payload_len <= desc_len) return PJ_ETOOSMALL;
+
+    if (pktz->cfg.fmt_id == PJMEDIA_FORMAT_VP8) {
+        /*  0 1 2 3 4 5 6 7
+         * +-+-+-+-+-+-+-+-+
+         * |X|R|N|S|R| PID | (REQUIRED)
+         */
+	/* X: Extended control bits present. */
+	if (p[0] & 0x80) {
+	    INC_DESC_LEN();
+	    /* |I|L|T|K| RSV   | */
+	    /* I: PictureID present. */
+	    if (p[1] & 0x80) {
+	    	INC_DESC_LEN();
+	    	/* If M bit is set, the PID field MUST contain 15 bits. */
+	    	if (p[2] & 0x80) INC_DESC_LEN();
+	    }
+	    /* L: TL0PICIDX present. */
+	    if (p[1] & 0x40) INC_DESC_LEN();
+	    /* T: TID present or K: KEYIDX present. */
+	    if ((p[1] & 0x20) || (p[1] & 0x10)) INC_DESC_LEN();
+	}
+
+    } else if (pktz->cfg.fmt_id == PJMEDIA_FORMAT_VP9) {
+        /*  0 1 2 3 4 5 6 7
+         * +-+-+-+-+-+-+-+-+
+         * |I|P|L|F|B|E|V|-| (REQUIRED)
+         */
+        /* I: Picture ID (PID) present. */
+	if (p[0] & 0x80) {
+	    INC_DESC_LEN();
+	    /* If M bit is set, the PID field MUST contain 15 bits. */
+	    if (p[1] & 0x80) INC_DESC_LEN();
+	}
+	/* L: Layer indices present. */
+	if (p[0] & 0x20) {
+	    INC_DESC_LEN();
+	    if (!(p[0] & 0x10)) INC_DESC_LEN();
+	}
+	/* F: Flexible mode.
+	 * I must also be set to 1, and if P is set, there's up to 3
+	 * reference index.
+	 */
+	if ((p[0] & 0x10) && (p[0] & 0x80) && (p[0] & 0x40)) {
+	    unsigned char *q = p + desc_len;
+
+	    INC_DESC_LEN();
+	    if (*q & 0x1) {
+	    	q++;
+	    	INC_DESC_LEN();
+	    	if (*q & 0x1) {
+	    	    q++;
+	    	    INC_DESC_LEN();
+	    	}
+	    }
+	}
+	/* V: Scalability structure (SS) data present. */
+	if (p[0] & 0x2) {
+	    unsigned char *q = p + desc_len;
+	    unsigned N_S = (*q >> 5) + 1;
+
+	    INC_DESC_LEN();
+	    /* Y: Each spatial layer's frame resolution present. */
+	    if (*q & 0x10) desc_len += N_S * 4;
+
+	    /* G: PG description present flag. */
+	    if (*q & 0x8) {
+	    	unsigned j;
+	    	unsigned N_G = *(p + desc_len);
+
+	    	INC_DESC_LEN();
+	    	for (j = 0; j< N_G; j++) {
+	    	    unsigned R;
+
+	    	    q = p + desc_len;
+	    	    INC_DESC_LEN();
+	    	    R = (*q & 0x0F) >> 2;
+	    	    desc_len += R;
+	    	    if (desc_len >= payload_len)
+	    	    	return PJ_ETOOSMALL;
+	    	}
+	    }
+	}
+    }
+#undef INC_DESC_LEN
+
+    *payload_desc_len = desc_len;
+    return PJ_SUCCESS;
+}
+
+
+#endif /* PJMEDIA_HAS_VIDEO */

--- a/pjsip/src/pjsua-lib/pjsua_vid.c
+++ b/pjsip/src/pjsua-lib/pjsua_vid.c
@@ -85,6 +85,15 @@ pj_status_t pjsua_vid_subsys_init(void)
     }
 #endif
 
+#if PJMEDIA_HAS_VIDEO && PJMEDIA_HAS_ANDROID_MEDIACODEC
+    status = pjmedia_codec_and_media_vid_init(NULL, &pjsua_var.cp.factory);
+    if (status != PJ_SUCCESS) {
+	pjsua_perror(THIS_FILE, "Error initializing AMediaCodec library",
+		     status);
+	goto on_error;
+    }
+#endif
+
 #if PJMEDIA_HAS_VIDEO && PJMEDIA_HAS_OPENH264_CODEC
     status = pjmedia_codec_openh264_vid_init(NULL, &pjsua_var.cp.factory);
     if (status != PJ_SUCCESS) {
@@ -169,6 +178,11 @@ pj_status_t pjsua_vid_subsys_destroy(void)
 
 #if PJMEDIA_HAS_VIDEO && PJMEDIA_HAS_VID_TOOLBOX_CODEC
     pjmedia_codec_vid_toolbox_deinit();
+#endif
+
+#if defined(PJMEDIA_HAS_ANDROID_MEDIACODEC) && \
+    PJMEDIA_HAS_ANDROID_MEDIACODEC != 0
+    pjmedia_codec_and_media_vid_deinit();
 #endif
 
 #if defined(PJMEDIA_HAS_OPENH264_CODEC) && PJMEDIA_HAS_OPENH264_CODEC != 0


### PR DESCRIPTION
* Implement android AMediaCodec AVC/VPX codec.

* - Change "anmed" to "and_media" prefix for clearity.
- Check if encoder/decoder exists before enabling codec.

* Fix bug on enum info.

* Add support to AMRNB and AMRWB audio codec.

* Modification based on comments.

* - move VPX packetizer from codec implementation.

* - Remove unwanted changes.
- Fix bug on vpx (VP9) packetize method.

* - New method to initialize vpx packetizer config.
- Don't use pt as codec id.

* add compiler option to prioritze using software or hardware codec.

* add documentation related to packetization mode for H264.

* fix some potential compile error.

* Specify video codec PT to support #2656.